### PR TITLE
Added needed LUFA files and LUFA license. Fixed LUFA_PATH in makefile

### DIFF
--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -93,7 +93,7 @@ SRC         += Terminal/Terminal.c Terminal/Commands.c Terminal/XModem.c Termina
 SRC         += Codec/Codec.c Codec/ISO14443-2A.c Codec/Reader14443-2A.c
 SRC         += Application/MifareUltralight.c Application/MifareClassic.c Application/ISO14443-3A.c Application/Crypto1.c Application/Reader14443A.c
 SRC         += $(LUFA_SRC_USB) $(LUFA_SRC_USBCLASS)
-LUFA_PATH    = ../LUFA
+LUFA_PATH    = src/LUFA/LUFA
 CC_FLAGS     = -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=$(FLASH_DATA_ADDR) -DFLASH_DATA_SIZE=$(FLASH_DATA_SIZE) -DSPM_HELPER_ADDR=$(SPM_HELPER_ADDR) -DBUILD_DATE=$(BUILD_DATE) -DCOMMIT_ID=\"$(COMMIT_ID)\" $(SETTINGS)
 LD_FLAGS     = -Wl,--section-start=.flashdata=$(FLASH_DATA_ADDR) -Wl,--section-start=.spmhelper=$(SPM_HELPER_ADDR)
 OBJDIR       = Bin

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/.gitignore
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/.gitignore
@@ -1,0 +1,9 @@
+*.lss
+*.bin
+*.elf
+*.hex
+*.eep
+*.map
+*.o
+*.d
+*.sym

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/HID_EEPROM_Loader.c
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/HID_EEPROM_Loader.c
@@ -1,0 +1,39 @@
+/*
+             DMBS Build System
+      Released into the public domain.
+
+   dean [at] fourwalledcubicle [dot] com
+         www.fourwalledcubicle.com
+ */
+
+/** \file
+ *
+ *  Special application to extract an EEPROM image stored in FLASH memory, and
+ *  copy it to the device EEPROM. This application is designed to be used with
+ *  the HID build system module of DMBS to program the EEPROM of a target device
+ *  that uses the HID bootloader protocol, which does not have native EEPROM
+ *  programming support.
+ */
+
+#include <avr/io.h>
+#include <avr/eeprom.h>
+#include <avr/pgmspace.h>
+
+/* References to the binary EEPROM data linked in the AVR's FLASH memory space */
+extern const char _binary_InputEEData_bin_start[];
+extern const char _binary_InputEEData_bin_end[];
+extern const char _binary_InputEEData_bin_size[];
+
+/* Friendly names for the embedded binary data stored in FLASH memory space */
+#define InputEEData       _binary_InputEEData_bin_start
+#define InputEEData_size  ((int)_binary_InputEEData_bin_size)
+
+int main(void)
+{
+	/* Copy out the embedded EEPROM data from FLASH to EEPROM memory space */
+	for (uint16_t i = 0; i < InputEEData_size; i++)
+	  eeprom_update_byte((uint8_t*)i, pgm_read_byte(&InputEEData[i]));
+
+	/* Infinite loop once complete */
+	for (;;);
+}

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/makefile
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/HID_EEPROM_Loader/makefile
@@ -1,0 +1,35 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+# Run "make help" for target help.
+
+MCU          = atmega128
+ARCH         = AVR8
+F_CPU        = 1000000
+OPTIMIZATION = s
+TARGET       = HID_EEPROM_Loader
+SRC          = $(TARGET).c
+CC_FLAGS     =
+LD_FLAGS     =
+OBJECT_FILES = InputEEData.o
+
+# Default target
+all:
+
+# Determine the AVR sub-architecture of the build main application object file
+FIND_AVR_SUBARCH = avr$(shell avr-objdump -f $(TARGET).o | grep architecture | cut -d':' -f3 | cut -d',' -f1)
+
+# Create a linkable object file with the input binary EEPROM data stored in the FLASH section
+InputEEData.o: InputEEData.bin $(TARGET).o $(MAKEFILE_LIST)
+	@echo $(MSG_OBJCPY_CMD) Converting \"$<\" to a object file \"$@\"
+	avr-objcopy -I binary -O elf32-avr -B $(call FIND_AVR_SUBARCH) --rename-section .data=.progmem.data,contents,alloc,readonly,data $< $@
+
+# Include LUFA build script makefiles
+include ../core.mk
+include ../gcc.mk
+include ../hid.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/License.txt
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/License.txt
@@ -1,0 +1,32 @@
+             DMBS Build System
+      Released into the public domain.
+
+   dean [at] fourwalledcubicle [dot] com
+         www.fourwalledcubicle.com
+
+
+
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/ModulesOverview.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/ModulesOverview.md
@@ -1,0 +1,38 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Modules Overview
+----------------
+
+The following modules are currently included:
+
+ - [ATPROGRAM](atprogram.md) - Device Programming
+ - [AVRDUDE](avrdude.md) - Device Programming
+ - [CORE](core.md) - DMBS Core Functionality
+ - [CPPCHECK](cppcheck.md) - Static Code Analysis
+ - [DFU](dfu.md) - Device Programming
+ - [DOXYGEN](doxygen.md) - Automated Source Code Documentation
+ - [GCC](gcc.md) - Compiling/Assembling/Linking with GCC
+ - [HID](hid.md) - Device Programming
+
+## Importing modules into your project makefile
+
+To use a module, it is recommended to add the following boilerplate to your
+makefile:
+
+    # Include DMBS build script makefiles
+    DMBS_PATH   ?= ../DMBS
+
+Which can then used to indicate the location of your DMBS installation, relative
+to the current directory, when importing modules. For example:
+
+    DMBS_PATH   ?= ../DMBS
+    include $(DMBS_PATH)/core.mk
+    include $(DMBS_PATH)/gcc.mk
+
+Imports the `CORE` and `GCC` modules from DMBS using a single path relative to
+your project's makefile.
+
+If you wish to write your own DMBS module(s),
+[see the documentation here for more details.](WritingYourOwnModules.md)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/WritingYourOwnModules.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/WritingYourOwnModules.md
@@ -1,0 +1,95 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Writing Your Own Modules
+------------------------
+
+A DMBS module consists of the several boilerplate sections, explained below.
+
+## The DMBS module hooks
+
+Your module needs to advertise to DMBS its name, its makefile targets, the
+required and optional variables, and the variables and macros the module
+provides for use elsewhere. This is achieved with the following section:
+
+    DMBS_BUILD_MODULES         += EXAMPLE
+    DMBS_BUILD_TARGETS         += example-target another-target
+    DMBS_BUILD_MANDATORY_VARS  += MANDATORY_NAME ALSO_MANDATORY
+    DMBS_BUILD_OPTIONAL_VARS   += OPTIONAL_NAME ALSO_OPTIONAL
+    DMBS_BUILD_PROVIDED_VARS   += MEANING_OF_LIFE
+    DMBS_BUILD_PROVIDED_MACROS += STRIP_WHITESPACE
+
+The example above declares that this module is called `EXAMPLE`, and exposes the
+listed targets, variable requirements and provides variables and macros.
+
+Your module name and provided variable/macro names must be unique, however you
+can (and should) re-use variable names where appropriate if they apply to
+several modules (such as `ARCH` to specify the project's microcontroller
+architecture). Re-using targets is not recommended, but can be used to extend
+the dependencies of another module's targets.
+
+## Importing the CORE module
+
+Next, your module should always import the DMBS `CORE` module, via the
+following:
+
+    # Conditionally import the CORE module of DMBS if it is not already imported
+    DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+    ifeq ($(findstring CORE, $(DMBS_BUILD_MODULES)),)
+      include $(DMBS_MODULE_PATH)/core.mk
+    endif
+
+This ensures that the `make help` target is always available. In addition, the
+`CORE` module exposes some [commonly used macros and variables](core.md) to
+your module.
+
+## Setting optional variable's defaults
+
+If a variable is optional, you should provide a default value. Do this via the
+`?=` operator of `make`, which sets a variable's value if it has not yet been
+set:
+
+    MY_OPTIONAL_VARIABLE ?= some_default_value
+
+## Sanity checking user input
+
+Sanity checks are what make DMBS useful. Where possible, validate user input and
+convert generated errors to human-friendly messages. This can be achieved by
+enforcing that all the declared module mandatory variables have been set by the
+user:
+
+    # Sanity-check values of mandatory user-supplied variables
+    $(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+
+As well as complaining if they are set, but currently empty:
+
+    $(call ERROR_IF_EMPTY, SOME_MANDATORY_VARIABLE)
+    $(call ERROR_IF_EMPTY, SOME_OPTIONAL_BUT_NON_EMPTY_VARIABLE)
+
+Or even if they are boolean (`Y` or `N`) variables that have an invalid value:
+
+    $(call ERROR_IF_NONBOOL, SOME_BOOL_VARIABLE)
+
+## Adding targets
+
+The meat of a DMBS module is the targets, which are run when the user types
+`make {target name}` from the command line. These can be as complex or simple
+as you like. See the GNU make manual for information on writing make targets.
+
+    example-target:
+        echo "Your DMBS module works!"
+
+## And finally, list the PHONYs
+
+Important in GNU Make is the concept of phony targets; this special directive
+tells make that a given target should never be considered a valid file. Listing
+phonies ensures that, for example, if your module had a target called `build`,
+it would always run when the user types `make build` from the command line, even
+if a file called `build` existed in the user project folder.
+
+You can list module-internal targets here, as well as mark all public targets
+via the module header's `DMBS_BUILD_TARGETS` variable.
+
+    # Phony build targets for this module
+    .PHONY: $(DMBS_BUILD_TARGETS) some-module-internal-target another-internal-target

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/atprogram.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/atprogram.md
@@ -1,0 +1,119 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Module: ATPROGRAM
+-----------------
+
+The ATPROGRAM module provides build targets for use with the official
+`ATPROGRAM` back-end utility distributed with the free
+[Atmel Studio](http://www.atmel.com) software released by Atmel.
+
+## Importing This Module into a Makefile:
+
+To use this module in your application makefile, add the following code to your
+makefile:
+
+    include $(DMBS_PATH)/atprogram.mk
+
+## Prerequisites:
+
+This module requires the `atprogram.exe` utility to be available in your
+system's `PATH` variable. The `atprogram.exe` utility is distributed in Atmel
+Studio (usually) inside the application install folder's `atbackend`
+subdirectory.
+
+## Build Targets:
+
+The following targets are supported by this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>atprogram</td>
+    <td>Program the device FLASH memory with the application's executable data.</td>
+   </tr>
+   <tr>
+    <td>atprogram-ee</td>
+    <td>Program the device EEPROM memory with the application's EEPROM data.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Mandatory Variables:
+
+The following variables must be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile to be able to use this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>MCU</td>
+    <td>Name of the Atmel processor model (e.g. `at90usb1287`).</td>
+   </tr>
+   <tr>
+    <td>TARGET</td>
+    <td>Name of the application output file prefix (e.g. `TestApplication`).</td>
+   </tr>
+ </tbody>
+</table>
+
+## Optional Variables:
+
+The following variables may be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile. If not specified, a default value will
+be assumed.
+
+<table>
+ <tbody>
+   <tr>
+    <td>ATPROGRAM_PROGRAMMER</td>
+    <td>Name of the Atmel programmer or debugger tool to communicate with (e.g. `jtagice3`). Default is `atmelice`.</td>
+   </tr>
+   <tr>
+    <td>ATPROGRAM_INTERFACE</td>
+    <td>Name of the programming interface to use when programming the target (e.g. `spi`). Default is `jtag`.</td>
+   </tr>
+   <tr>
+    <td>ATPROGRAM_PORT</td>
+    <td>Name of the communication port to use when when programming with a serially connected tool (e.g. `COM2`). Default is `usb`.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Variables:
+
+The following variables may be referenced in a user makefile (via `$(NAME)`
+syntax) if desired, as they are provided by this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Macros:
+
+The following macros may be referenced in a user makefile (via
+`$(call NAME, ARG1, ARG2, ...)` syntax) if desired, as they are provided by
+this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no macros.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Module Changelog:
+
+The changes to this module since its initial release are listed below, as of the
+DMBS version where the change was made.
+
+### 20160403
+Initial release.

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/atprogram.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/atprogram.mk
@@ -1,0 +1,68 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+DMBS_BUILD_MODULES         += ATPROGRAM
+DMBS_BUILD_TARGETS         += atprogram atprogram-ee
+DMBS_BUILD_MANDATORY_VARS  += MCU TARGET
+DMBS_BUILD_OPTIONAL_VARS   += ATPROGRAM_PROGRAMMER ATPROGRAM_INTERFACE ATPROGRAM_PORT
+DMBS_BUILD_PROVIDED_VARS   +=
+DMBS_BUILD_PROVIDED_MACROS +=
+
+# Conditionally import the CORE module of DMBS if it is not already imported
+DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+ifeq ($(findstring CORE, $(DMBS_BUILD_MODULES)),)
+  include $(DMBS_MODULE_PATH)/core.mk
+endif
+
+# Default values of optionally user-supplied variables
+ATPROGRAM_PROGRAMMER ?= atmelice
+ATPROGRAM_INTERFACE  ?= jtag
+ATPROGRAM_PORT       ?=
+
+# Sanity check user supplied values
+$(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+$(call ERROR_IF_EMPTY, MCU)
+$(call ERROR_IF_EMPTY, TARGET)
+$(call ERROR_IF_EMPTY, ATPROGRAM_PROGRAMMER)
+$(call ERROR_IF_EMPTY, ATPROGRAM_INTERFACE)
+
+# Output Messages
+MSG_ATPROGRAM_CMD    := ' [ATPRGRM] :'
+
+# Construct base atprogram command flags
+BASE_ATPROGRAM_FLAGS := --tool $(ATPROGRAM_PROGRAMMER) --interface $(ATPROGRAM_INTERFACE) --device $(MCU)
+ifneq ($(ATPROGRAM_PORT),)
+   BASE_ATPROGRAM_FLAGS += --port $(ATPROGRAM_PORT)
+endif
+
+# Construct the flags to use for the various memory spaces
+ifeq ($(ARCH), AVR8)
+   ATPROGRAM_FLASH_FLAGS  := --chiperase --flash
+   ATPROGRAM_EEPROM_FLAGS := --eeprom
+else ifeq ($(ARCH), XMEGA)
+   ATPROGRAM_FLASH_FLAGS  := --erase --flash
+   ATPROGRAM_EEPROM_FLAGS := --eeprom
+else ifeq ($(ARCH), UC3)
+   ATPROGRAM_FLASH_FLAGS  := --erase
+   ATPROGRAM_EEPROM_FLAGS := --eeprom
+else
+   $(error Unsupported architecture "$(ARCH)")
+endif
+
+# Programs in the target FLASH memory using ATPROGRAM
+atprogram: $(TARGET).elf $(MAKEFILE_LIST)
+	@echo $(MSG_ATPROGRAM_CMD) Programming device \"$(MCU)\" FLASH using \"$(ATPROGRAM_PROGRAMMER)\"
+	atprogram $(BASE_ATPROGRAM_FLAGS) program $(ATPROGRAM_FLASH_FLAGS) --file $<
+
+# Programs in the target EEPROM memory using ATPROGRAM
+atprogram-ee: $(TARGET).elf $(MAKEFILE_LIST)
+	@echo $(MSG_ATPROGRAM_CMD) Programming device \"$(MCU)\" EEPROM using \"$(ATPROGRAM_PROGRAMMER)\"
+	atprogram $(BASE_ATPROGRAM_FLAGS) program $(ATPROGRAM_EEPROM_FLAGS) --file $<
+
+# Phony build targets for this module
+.PHONY: $(DMBS_BUILD_TARGETS)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/avrdude.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/avrdude.md
@@ -1,0 +1,124 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Module: AVRDUDE
+-----------------
+
+The AVRDUDE module provides build targets for use with the official
+open source `AVRDUDE` programmer utility, for the reprogramming of Atmel devices
+using a wide variety of official and non-official programming devices and
+bootloaders.
+
+## Importing This Module into a Makefile:
+
+To use this module in your application makefile, add the following code to your
+makefile:
+
+    include $(DMBS_PATH)/avrdude.mk
+
+## Prerequisites:
+
+This module requires the `avrdude` utility to be available in your
+system's `PATH` variable. The `avrdude` utility is distributed on the project's
+[official site](https://savannah.nongnu.org/projects/avrdude) but is also
+made available in many *nix operating system's package managers.
+
+## Build Targets:
+
+The following targets are supported by this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>avrdude</td>
+    <td>Program the device FLASH memory with the application's executable data.</td>
+   </tr>
+   <tr>
+    <td>avrdude-ee</td>
+    <td>Program the device EEPROM memory with the application's EEPROM data.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Mandatory Variables:
+
+The following variables must be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile to be able to use this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>MCU</td>
+    <td>Name of the Atmel processor model (e.g. `at90usb1287`).</td>
+   </tr>
+   <tr>
+    <td>TARGET</td>
+    <td>Name of the application output file prefix (e.g. `TestApplication`).</td>
+   </tr>
+ </tbody>
+</table>
+
+## Optional Variables:
+
+The following variables may be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile. If not specified, a default value will
+be assumed.
+
+<table>
+ <tbody>
+   <tr>
+    <td>AVRDUDE_PROGRAMMER</td>
+    <td>Name of the programmer/debugger tool or bootloader to communicate with (e.g. `jtagicemkii`). Default is `jtagicemkii`.</td>
+   </tr>
+   <tr>
+    <td>AVRDUDE_PORT</td>
+    <td>Name of the communication port to use when when programming with a serially connected tool (e.g. `COM2`). Default is `usb`.</td>
+   </tr>
+   <tr>
+    <td>AVRDUDE_FLAGS</td>
+    <td>Additional flags to pass to `avrdude` when invoking the tool. Default is empty (no additional flags).</td>
+   </tr>
+   <tr>
+    <td>AVRDUDE_MEMORY</td>
+    <td>Memory space to program when executing the `avrdude` target (e.g. 'application` for an XMEGA device). Default is `flash`.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Variables:
+
+The following variables may be referenced in a user makefile (via `$(NAME)`
+syntax) if desired, as they are provided by this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Macros:
+
+The following macros may be referenced in a user makefile (via
+`$(call NAME, ARG1, ARG2, ...)` syntax) if desired, as they are provided by
+this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no macros.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Module Changelog:
+
+The changes to this module since its initial release are listed below, as of the
+DMBS version where the change was made.
+
+### 20160403
+Initial release.

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/avrdude.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/avrdude.mk
@@ -1,0 +1,52 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+DMBS_BUILD_MODULES         += AVRDUDE
+DMBS_BUILD_TARGETS         += avrdude avrdude-ee
+DMBS_BUILD_MANDATORY_VARS  += MCU TARGET
+DMBS_BUILD_OPTIONAL_VARS   += AVRDUDE_PROGRAMMER AVRDUDE_PORT AVRDUDE_FLAGS AVRDUDE_MEMORY
+DMBS_BUILD_PROVIDED_VARS   +=
+DMBS_BUILD_PROVIDED_MACROS +=
+
+# Conditionally import the CORE module of DMBS if it is not already imported
+DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+ifeq ($(findstring CORE, $(DMBS_BUILD_MODULES)),)
+  include $(DMBS_MODULE_PATH)/core.mk
+endif
+
+# Default values of optionally user-supplied variables
+AVRDUDE_PROGRAMMER ?= jtagicemkii
+AVRDUDE_PORT       ?= usb
+AVRDUDE_FLAGS      ?=
+AVRDUDE_MEMORY     ?= flash
+
+# Sanity check user supplied values
+$(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+$(call ERROR_IF_EMPTY, MCU)
+$(call ERROR_IF_EMPTY, TARGET)
+$(call ERROR_IF_EMPTY, AVRDUDE_PROGRAMMER)
+$(call ERROR_IF_EMPTY, AVRDUDE_PORT)
+
+# Output Messages
+MSG_AVRDUDE_CMD    := ' [AVRDUDE] :'
+
+# Construct base avrdude command flags
+BASE_AVRDUDE_FLAGS := -p $(MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
+
+# Programs in the target FLASH memory using AVRDUDE
+avrdude: $(TARGET).hex $(MAKEFILE_LIST)
+	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(MCU)\" FLASH using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
+	avrdude $(BASE_AVRDUDE_FLAGS) -U $(AVRDUDE_MEMORY):w:$< $(AVRDUDE_FLAGS)
+
+# Programs in the target EEPROM memory using AVRDUDE
+avrdude-ee: $(TARGET).eep $(MAKEFILE_LIST)
+	@echo $(MSG_AVRDUDE_CMD) Programming device \"$(MCU)\" EEPROM using \"$(AVRDUDE_PROGRAMMER)\" on port \"$(AVRDUDE_PORT)\"
+	avrdude $(BASE_AVRDUDE_FLAGS) -U eeprom:w:$< $(AVRDUDE_FLAGS)
+
+# Phony build targets for this module
+.PHONY: $(DMBS_BUILD_TARGETS)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/core.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/core.md
@@ -1,0 +1,136 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Module: CORE
+------------
+
+The CORE module provides the core DMBS infrastructure used by other DMBS
+modules, and must always be imported. Additionally, this module provides the
+help system for DMBS.
+
+## Importing This Module into a Makefile:
+
+To use this module in your application makefile, add the following code to your
+makefile:
+
+    include $(DMBS_PATH)/core.mk
+
+## Prerequisites:
+
+None.
+
+## Build Targets:
+
+The following targets are supported by this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>help</td>
+    <td>Show help for the current project, including a list of all available targets, variables and macros from the imported modules.</td>
+   </tr>
+   <tr>
+    <td>list_targets</td>
+    <td>Show a list of all build targets from the imported modules.</td>
+   </tr>
+   <tr>
+    <td>list_modules</td>
+    <td>Show a list of all imported modules.</td>
+   </tr>
+   <tr>
+    <td>list_mandatory</td>
+    <td>Show a list of all mandatory variables from the imported modules.</td>
+   </tr>
+   <tr>
+    <td>list_optional</td>
+    <td>Show a list of all optional variables from the imported modules.</td>
+   </tr>
+   <tr>
+    <td>list_provided</td>
+    <td>Show a list of all variables provided by the imported modules.</td>
+   </tr>
+   <tr>
+    <td>list_macros</td>
+    <td>Show a list of all macros provided by the imported modules.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Mandatory Variables:
+
+The following variables must be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile to be able to use this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module has no mandatory variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Optional Variables:
+
+The following variables may be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile. If not specified, a default value will
+be assumed.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module has no optional variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Variables:
+
+The following variables may be referenced in a user makefile (via `$(NAME)`
+syntax) if desired, as they are provided by this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>DMBS_VERSION</td>
+    <td>Current version of this DMBS release, as a ISO 8601 integer (such as `20160403` for `2016-04-03`).</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Macros:
+
+The following macros may be referenced in a user makefile (via
+`$(call NAME, ARG1, ARG2, ...)` syntax) if desired, as they are provided by
+this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>DMBS_CHECK_VERSION</td>
+    <td>Macro to check the current DMBS version against the first argument and abort if the required version is newer than the current version.</td>
+   </tr>
+   <tr>
+    <td>ERROR_IF_UNSET</td>
+    <td>Macro to check the given makefile variable name passed as the first argument, and abort if it has not been set by any makefile module.</td>
+   </tr>
+   <tr>
+    <td>ERROR_IF_EMPTY</td>
+    <td>Macro to check the given makefile variable name passed as the first argument, and abort if it has an empty value.</td>
+   </tr>
+   <tr>
+    <td>ERROR_IF_NONBOOL</td>
+    <td>Macro to check the given makefile variable name passed as the first argument, and abort if it has a value other than `Y` or `N`.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Module Changelog:
+
+The changes to this module since its initial release are listed below, as of the
+DMBS version where the change was made.
+
+### 20160403
+Initial release.

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/core.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/core.mk
@@ -1,0 +1,147 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+DMBS_BUILD_MODULES         += CORE
+DMBS_BUILD_TARGETS         += help list_targets list_modules list_mandatory list_optional list_provided list_macros
+DMBS_BUILD_MANDATORY_VARS  +=
+DMBS_BUILD_OPTIONAL_VARS   +=
+DMBS_BUILD_PROVIDED_VARS   += DMBS_VERSION
+DMBS_BUILD_PROVIDED_MACROS += DMBS_CHECK_VERSION ERROR_IF_UNSET ERROR_IF_EMPTY ERROR_IF_NONBOOL
+
+SHELL = /bin/sh
+
+# Current DMBS release version
+DMBS_VERSION       := 20170426
+
+# Macro to check the DMBS version, aborts if the given DMBS version is below the current version
+DMBS_CHECK_VERSION ?= $(if $(filter-out 0, $(shell test $(DMBS_VERSION) -lt $(1); echo $$?)), , $(error DMBS version $(1) or newer required, current version is $(DMBS_VERSION)))
+
+# Macros to use in other modules to check various conditions
+ERROR_IF_UNSET     ?= $(if $(filter undefined, $(origin $(strip $(1)))), $(error Makefile $(strip $(1)) value not set))
+ERROR_IF_EMPTY     ?= $(if $(strip $($(strip $(1)))), , $(error Makefile $(strip $(1)) option cannot be blank))
+ERROR_IF_NONBOOL   ?= $(if $(filter Y N, $($(strip $(1)))), , $(error Makefile $(strip $(1)) option must be Y or N))
+
+# Converts a given input to a printable output using "(None)" if no items are in the list
+CONVERT_TO_PRINTABLE           = $(if $(strip $(1)), $(1), (None))
+
+# Build sorted and filtered lists of the included build module data
+SORTED_DMBS_BUILD_MODULES      = $(sort $(DMBS_BUILD_MODULES))
+SORTED_DMBS_BUILD_TARGETS      = $(sort $(DMBS_BUILD_TARGETS))
+SORTED_DMBS_MANDATORY_VARS     = $(sort $(DMBS_BUILD_MANDATORY_VARS))
+SORTED_DMBS_OPTIONAL_VARS      = $(filter-out $(SORTED_DMBS_MANDATORY_VARS), $(sort $(DMBS_BUILD_OPTIONAL_VARS)))
+SORTED_DMBS_PROVIDED_VARS      = $(sort $(DMBS_BUILD_PROVIDED_VARS))
+SORTED_DMBS_PROVIDED_MACROS    = $(sort $(DMBS_BUILD_PROVIDED_MACROS))
+
+# Create printable versions of the sorted build module data (use "(None)" when no data is available)
+PRINTABLE_DMBS_BUILD_MODULES   = $(call CONVERT_TO_PRINTABLE, $(SORTED_DMBS_BUILD_MODULES))
+PRINTABLE_DMBS_BUILD_TARGETS   = $(call CONVERT_TO_PRINTABLE, $(SORTED_DMBS_BUILD_TARGETS))
+PRINTABLE_DMBS_MANDATORY_VARS  = $(call CONVERT_TO_PRINTABLE, $(SORTED_DMBS_MANDATORY_VARS))
+PRINTABLE_DMBS_OPTIONAL_VARS   = $(call CONVERT_TO_PRINTABLE, $(SORTED_DMBS_OPTIONAL_VARS))
+PRINTABLE_DMBS_PROVIDED_VARS   = $(call CONVERT_TO_PRINTABLE, $(SORTED_DMBS_PROVIDED_VARS))
+PRINTABLE_DMBS_PROVIDED_MACROS = $(call CONVERT_TO_PRINTABLE, $(SORTED_DMBS_PROVIDED_MACROS))
+
+help:
+	@echo "==================================================================="
+	@echo "                       The DMBS Build System                       "
+	@echo "         By Dean Camera { dean @ fourwalledcubicle . com }         "
+	@echo "==================================================================="
+	@echo "DESCRIPTION:                                                       "
+	@echo " This build system is a set of makefile modules for (GNU) Make, to "
+	@echo " provide a simple system for building DMBS powered applications.   "
+	@echo " Each makefile module can be included from within a user makefile, "
+	@echo " to expose the build rules documented in the comments at the top of"
+	@echo " each build module.                                                "
+	@echo "                                                                   "
+	@echo "USAGE:                                                             "
+	@echo " To execute a rule, define all variables indicated in the desired  "
+	@echo " module as a required parameter before including the build module  "
+	@echo " in your project makefile. Parameters marked as optional will      "
+	@echo " assume a default value in the modules if not user-assigned.       "
+	@echo "                                                                   "
+	@echo " By default the target output shows both a friendly summary, as    "
+	@echo " well as the actual invoked command. To suppress the output of the "
+	@echo " invoked commands and show only the friendly command output, run   "
+	@echo " make with the \"-s\" switch added before the target(s).           "
+	@echo "==================================================================="
+	@echo "                                                                   "
+	@echo "  Currently used build system modules in this application:         "
+	@echo "                                                                   "
+	@printf " %b" "$(PRINTABLE_DMBS_BUILD_MODULES:%=   - %\n)"
+	@echo "                                                                   "
+	@echo "                                                                   "
+	@echo "  Currently available build targets in this application:           "
+	@echo "                                                                   "
+	@printf " %b" "$(PRINTABLE_DMBS_BUILD_TARGETS:%=   - %\n)"
+	@echo "                                                                   "
+	@echo "                                                                   "
+	@echo "  Mandatory variables required by the selected build Modules:      "
+	@echo "                                                                   "
+	@printf " %b" "$(PRINTABLE_DMBS_MANDATORY_VARS:%=   - %\n)"
+	@echo "                                                                   "
+	@echo "                                                                   "
+	@echo "  Optional variables required by the selected build Modules:       "
+	@echo "                                                                   "
+	@printf " %b" "$(PRINTABLE_DMBS_OPTIONAL_VARS:%=   - %\n)"
+	@echo "                                                                   "
+	@echo "                                                                   "
+	@echo "  Variables provided by the selected build Modules:                "
+	@echo "                                                                   "
+	@printf " %b" "$(PRINTABLE_DMBS_PROVIDED_VARS:%=   - %\n)"
+	@echo "                                                                   "
+	@echo "                                                                   "
+	@echo "  Macros provided by the selected build Modules:                   "
+	@echo "                                                                   "
+	@printf " %b" "$(PRINTABLE_DMBS_PROVIDED_MACROS:%=   - %\n)"
+	@echo "                                                                   "
+	@echo "==================================================================="
+	@echo "          The DMBS Build System $(DMBS_VERSION) - Making MAKE easier."
+	@echo "==================================================================="
+
+# Lists build modules included by the project makefile, in alphabetical order
+list_modules:
+	@echo Currently Used Build System Modules:
+	@printf " %b" "$(PRINTABLE_DMBS_BUILD_MODULES:%=   - %\n)"
+
+# Lists build targets included by the project makefile, in alphabetical order
+list_targets:
+	@echo Currently Available Build Targets:
+	@printf " %b" "$(PRINTABLE_DMBS_BUILD_TARGETS:%=   - %\n)"
+
+# Lists mandatory variables that must be set by the project makefile, in alphabetical order
+list_mandatory:
+	@echo Mandatory Variables for Included Modules:
+	@printf " %b" "$(PRINTABLE_DMBS_MANDATORY_VARS:%=   - %\n)"
+
+# Lists optional variables that must be set by the project makefile, in alphabetical order
+list_optional:
+	@echo Optional Variables for Included Modules:
+	@printf " %b" "$(PRINTABLE_DMBS_OPTIONAL_VARS:%=   - %\n)"
+
+# Lists variables provided by the included build modules, in alphabetical order
+list_provided:
+	@echo Variables Provided by the Included Modules:
+	@printf " %b" "$(PRINTABLE_DMBS_PROVIDED_VARS:%=   - %\n)"
+
+# Lists macros provided by the included build modules, in alphabetical order
+list_macros:
+	@echo Macros Provided by the Included Modules:
+	@printf " %b" "$(PRINTABLE_DMBS_PROVIDED_MACROS:%=   - %\n)"
+
+# Debugging; "make print-VARNAME" will output the variable VARNAME's value
+print-%:
+	@printf "%s = %s" $(@:print-%=%) $($(@:print-%=%))
+
+# Disable default in-built make rules (those that are needed are explicitly
+# defined, and doing so has performance benefits when recursively building)
+ifeq ($(filter -r,$(MAKEFLAGS)),)
+  MAKEFLAGS += -r
+endif
+.SUFFIXES:
+
+# Phony build targets for this module
+.PHONY: $(DMBS_BUILD_TARGETS)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/cppcheck.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/cppcheck.md
@@ -1,0 +1,134 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Module: CPPCHECK
+-----------------
+
+The CPPCHECK module provides build targets to perform static analysis of the
+user application, using the open source `cppcheck` tool.
+
+## Importing This Module into a Makefile:
+
+To use this module in your application makefile, add the following code to your
+makefile:
+
+    include $(DMBS_PATH)/cppcheck.mk
+
+## Prerequisites:
+
+This module requires the `cppcheck` utility to be available in your system's
+`PATH` variable. The `cppcheck` utility is distributed on the project's
+[official site](http://cppcheck.sourceforge.net/) but is also
+made available in many *nix operating system's package managers.
+
+## Build Targets:
+
+The following targets are supported by this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>cppcheck</td>
+    <td>Scan the project with CPPCHECK, and show all discovered issues.</td>
+   </tr>
+   <tr>
+    <td>cppcheck-config</td>
+    <td>Check the project with CPPCHECK, to find missing header paths.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Mandatory Variables:
+
+The following variables must be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile to be able to use this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>SRC</td>
+    <td>List of all project source files to scan.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Optional Variables:
+
+The following variables may be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile. If not specified, a default value will
+be assumed.
+
+<table>
+ <tbody>
+   <tr>
+    <td>CPPCHECK_INCLUDES</td>
+    <td>Extra include paths to search, for any missing header files. Default is empty (no additional paths).</td>
+   </tr>
+   <tr>
+    <td>CPPCHECK_EXCLUDES</td>
+    <td>List of source files, file paths or path fragments to exclude from the scan. Default is empty (no exclusions).</td>
+   </tr>
+   <tr>
+    <td>CPPCHECK_MSG_TEMPLATE</td>
+    <td>Template for error and warning message output. Default is `{file}:{line}: {severity} ({id}): {message}`.</td>
+   </tr>
+   <tr>
+    <td>CPPCHECK_ENABLE</td>
+    <td>List of CPPCHECK checks to enable. Default is `all`.</td>
+   </tr>
+   <tr>
+    <td>CPPCHECK_SUPPRESS</td>
+    <td>List of CPPCHECK checks to ignore. Default is `variableScope missingInclude`.</td>
+   </tr>
+   <tr>
+    <td>CPPCHECK_FAIL_ON_WARNING</td>
+    <td>Boolean, if `Y` the build will fail if CPPCHECK discovers any errors or warnings. If `N`, fail only on errors. Default is `Y`.</td>
+   </tr>
+   <tr>
+    <td>CPPCHECK_QUIET</td>
+    <td>Boolean, if `Y` CPPCHECK will suppress all output except for discovered errors or warnings. If `N`, scan progress will be emitted. Default is `Y`.</td>
+   </tr>
+   <tr>
+    <td>CPPCHECK_FLAGS_</td>
+    <td>Additional flags to pass to CPPCHECK when scans are started. Default is empty (no additional flags).</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Variables:
+
+The following variables may be referenced in a user makefile (via `$(NAME)`
+syntax) if desired, as they are provided by this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Macros:
+
+The following macros may be referenced in a user makefile (via
+`$(call NAME, ARG1, ARG2, ...)` syntax) if desired, as they are provided by
+this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no macros.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Module Changelog:
+
+The changes to this module since its initial release are listed below, as of the
+DMBS version where the change was made.
+
+### 20160403
+Initial release.

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/cppcheck.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/cppcheck.mk
@@ -1,0 +1,66 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+DMBS_BUILD_MODULES         += CPPCHECK
+DMBS_BUILD_TARGETS         += cppcheck cppcheck-config
+DMBS_BUILD_MANDATORY_VARS  += SRC
+DMBS_BUILD_OPTIONAL_VARS   += CPPCHECK_INCLUDES CPPCHECK_EXCLUDES CPPCHECK_MSG_TEMPLATE CPPCHECK_ENABLE \
+                              CPPCHECK_SUPPRESS CPPCHECK_FAIL_ON_WARNING CPPCHECK_QUIET CPPCHECK_FLAGS
+DMBS_BUILD_PROVIDED_VARS   +=
+DMBS_BUILD_PROVIDED_MACROS +=
+
+# Conditionally import the CORE module of DMBS if it is not already imported
+DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+ifeq ($(findstring CORE, $(DMBS_BUILD_MODULES)),)
+  include $(DMBS_MODULE_PATH)/core.mk
+endif
+
+# Default values of optionally user-supplied variables
+CPPCHECK_INCLUDES            ?=
+CPPCHECK_EXCLUDES            ?=
+CPPCHECK_MSG_TEMPLATE        ?= {file}:{line}: {severity} ({id}): {message}
+CPPCHECK_ENABLE              ?= all
+CPPCHECK_SUPPRESS            ?= variableScope missingInclude
+CPPCHECK_FAIL_ON_WARNING     ?= Y
+CPPCHECK_QUIET               ?= Y
+CPPCHECK_FLAGS               ?=
+
+# Sanity check user supplied values
+$(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+$(call ERROR_IF_EMPTY, SRC)
+$(call ERROR_IF_EMPTY, CPPCHECK_MSG_TEMPLATE)
+$(call ERROR_IF_EMPTY, CPPCHECK_ENABLE)
+$(call ERROR_IF_NONBOOL, CPPCHECK_FAIL_ON_WARNING)
+$(call ERROR_IF_NONBOOL, CPPCHECK_QUIET)
+
+# Build a default argument list for cppcheck
+BASE_CPPCHECK_FLAGS := --template="$(CPPCHECK_MSG_TEMPLATE)" $(CPPCHECK_INCLUDES:%=-I%) $(CPPCHECK_EXCLUDES:%=-i%) --inline-suppr --force --std=c99
+
+# Sanity check parameters and construct additional command line arguments to cppcheck
+ifeq ($(CPPCHECK_FAIL_ON_WARNING), Y)
+   BASE_CPPCHECK_FLAGS += --error-exitcode=1
+endif
+ifeq ($(CPPCHECK_QUIET), Y)
+   BASE_CPPCHECK_FLAGS += --quiet
+endif
+
+# Output Messages
+MSG_CPPCHECK_CMD         := ' [CPPCHECK]:'
+
+# Checks the CPPCheck configuration as used in the user project, to determine if any paths are missing or invalid
+cppcheck-config: $(MAKEFILE_LIST)
+	@echo $(MSG_CPPCHECK_CMD) Checking cppcheck configuration check on source files
+	cppcheck $(BASE_CPPCHECK_FLAGS) --check-config $(CPPCHECK_FLAGS) $(SRC)
+
+# Runs a static analysis using CPPCheck to determine if there are any issues
+cppcheck: $(MAKEFILE_LIST)
+	@echo $(MSG_CPPCHECK_CMD) Performing static analysis on source files
+	cppcheck $(BASE_CPPCHECK_FLAGS) --enable=$(CPPCHECK_ENABLE) $(CPPCHECK_SUPPRESS:%=--suppress=%) $(CPPCHECK_FLAGS) $(SRC)
+
+# Phony build targets for this module
+.PHONY: $(DMBS_BUILD_TARGETS)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/dfu.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/dfu.md
@@ -1,0 +1,122 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Module: DFU
+-----------------
+
+The DFU module provides build targets to program a USB connected target running
+a DFU class bootloader, via the official Atmel FLIP utility running via the
+command line, or the open source `DFU-Programmer` tool.
+
+## Importing This Module into a Makefile:
+
+To use this module in your application makefile, add the following code to your
+makefile:
+
+    include $(DMBS_PATH)/dfu.mk
+
+## Prerequisites:
+
+This module requires the `batchisp` utility to be available in your system's
+`PATH` variable. The `batchisp` utility is distributed as part of Atmel's FLIP
+software which can be downloaded from the [official site](http://www.atmel.com).
+
+This module requires the `dfu-programmer` utility to be available in your
+system's `PATH` variable. The `dfu-programmer` utility is distributed from the
+[official project site](https://dfu-programmer.github.io/).
+
+## Build Targets:
+
+The following targets are supported by this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>flip</td>
+    <td>Program the application into the device's flash memory, using Atmel FLIP.</td>
+   </tr>
+   <tr>
+    <td>flip-ee</td>
+    <td>Program the application's EEPROM data into the device's EEPROM memory, using Atmel FLIP.</td>
+   </tr>
+   <tr>
+    <td>dfu</td>
+    <td>Program the application into the device's flash memory, using `dfu-programmer`.</td>
+   </tr>
+   <tr>
+    <td>dfu-ee</td>
+    <td>Program the application's EEPROM data into the device's EEPROM memory, using `dfu-programmer`.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Mandatory Variables:
+
+The following variables must be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile to be able to use this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>MCU</td>
+    <td>Name of the Atmel processor model (e.g. `at90usb1287`).</td>
+   </tr>
+   <tr>
+    <td>TARGET</td>
+    <td>Name of the application output file prefix (e.g. `TestApplication`).</td>
+   </tr>   
+ </tbody>
+</table>
+
+## Optional Variables:
+
+The following variables may be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile. If not specified, a default value will
+be assumed.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module has no optional variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Variables:
+
+The following variables may be referenced in a user makefile (via `$(NAME)`
+syntax) if desired, as they are provided by this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Macros:
+
+The following macros may be referenced in a user makefile (via
+`$(call NAME, ARG1, ARG2, ...)` syntax) if desired, as they are provided by
+this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no macros.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Module Changelog:
+
+The changes to this module since its initial release are listed below, as of the
+DMBS version where the change was made.
+
+### 20160403
+Initial release.

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/dfu.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/dfu.mk
@@ -1,0 +1,62 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+DMBS_BUILD_MODULES         += DFU
+DMBS_BUILD_TARGETS         += flip flip-ee dfu dfu-ee
+DMBS_BUILD_MANDATORY_VARS  += MCU TARGET
+DMBS_BUILD_OPTIONAL_VARS   +=
+DMBS_BUILD_PROVIDED_VARS   +=
+DMBS_BUILD_PROVIDED_MACROS +=
+
+# Conditionally import the CORE module of DMBS if it is not already imported
+DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+ifeq ($(findstring CORE, $(DMBS_BUILD_MODULES)),)
+  include $(DMBS_MODULE_PATH)/core.mk
+endif
+
+# Sanity-check values of mandatory user-supplied variables
+$(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+$(call ERROR_IF_EMPTY, MCU)
+$(call ERROR_IF_EMPTY, TARGET)
+
+# Output Messages
+MSG_COPY_CMD   := ' [CP]      :'
+MSG_REMOVE_CMD := ' [RM]      :'
+MSG_DFU_CMD    := ' [DFU]     :'
+
+# Programs in the target FLASH memory using BATCHISP, the command line tool used by FLIP
+flip: $(TARGET).hex $(MAKEFILE_LIST)
+	@echo $(MSG_DFU_CMD) Programming FLASH with batchisp using \"$<\"
+	batchisp -hardware usb -device $(MCU) -operation erase f loadbuffer $< program
+	batchisp -hardware usb -device $(MCU) -operation start reset 0
+
+# Programs in the target EEPROM memory using BATCHISP, the command line tool used by FLIP
+flip-ee: $(TARGET).eep $(MAKEFILE_LIST)
+	@echo $(MSG_COPY_CMD) Copying EEP file to temporary file \"$<.hex\"
+	cp $< $<.hex
+	@echo $(MSG_DFU_CMD) Programming EEPROM with batchisp using \"$<.hex\"
+	batchisp -hardware usb -device $(MCU) -operation memory EEPROM loadbuffer $<.hex program
+	batchisp -hardware usb -device $(MCU) -operation start reset 0
+	@echo $(MSG_REMOVE_CMD) Removing temporary file \"$<.hex\"
+	rm $<.hex
+
+# Programs in the target FLASH memory using DFU-PROGRAMMER
+dfu: $(TARGET).hex $(MAKEFILE_LIST)
+	@echo $(MSG_DFU_CMD) Programming FLASH with dfu-programmer using \"$<\"
+	dfu-programmer $(MCU) erase
+	dfu-programmer $(MCU) flash $<
+	dfu-programmer $(MCU) reset
+
+# Programs in the target EEPROM memory using DFU-PROGRAMMER
+dfu-ee: $(TARGET).eep $(MAKEFILE_LIST)
+	@echo $(MSG_DFU_CMD) Programming EEPROM with dfu-programmer using \"$<\"
+	dfu-programmer $(MCU) flash --eeprom $<
+	dfu-programmer $(MCU) reset
+
+# Phony build targets for this module
+.PHONY: $(DMBS_BUILD_TARGETS)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/doxygen.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/doxygen.md
@@ -1,0 +1,118 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Module: DOXYGEN
+-----------------
+
+The DOXYGEN module provides build targets to automatically generate API
+documentation for a project, using the open-source Doxygen tool.
+
+## Importing This Module into a Makefile:
+
+To use this module in your application makefile, add the following code to your
+makefile:
+
+    include $(DMBS_PATH)/doxygen.mk
+
+## Prerequisites:
+
+This module requires the `doxygen` utility to be available in your system's
+`PATH` variable. The `doxygen` utility is distributed on the project's
+[official site](http://doxygen.org/) but is also
+made available in many *nix operating system's package managers.
+
+## Build Targets:
+
+The following targets are supported by this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>doxygen</td>
+    <td>Generate project documentation, via Doxygen.</td>
+   </tr>
+   <tr>
+    <td>doxygen-create</td>
+    <td>Create a new project Doxygen template, which can then be customized.</td>
+   </tr>
+   <tr>
+    <td>doxygen-upgrade</td>
+    <td>Upgrade an existing project Doxygen template to the latest Doxygen version.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Mandatory Variables:
+
+The following variables must be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile to be able to use this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module has no mandatory variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Optional Variables:
+
+The following variables may be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile. If not specified, a default value will
+be assumed.
+
+<table>
+ <tbody>
+   <tr>
+    <td>DOXYGEN_CONF</td>
+    <td>Name of the Doxygen project configuration file that should be used when generating documentation, or creating/upgrading the configuration file.</td>
+   </tr>
+   <tr>
+    <td>DOXYGEN_FAIL_ON_WARNING</td>
+    <td>Boolean, if `Y` the build will fail if Doxygen encounters any errors or warnings. If `N`, fail only on errors. Default is `Y`.</td>
+   </tr>
+   <tr>
+    <td>DOXYGEN_OVERRIDE_PARAMS</td>
+    <td>List of `NAME=VALUE` parameters which should override the values specified in the project configuration file, when building documentation.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Variables:
+
+The following variables may be referenced in a user makefile (via `$(NAME)`
+syntax) if desired, as they are provided by this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Macros:
+
+The following macros may be referenced in a user makefile (via
+`$(call NAME, ARG1, ARG2, ...)` syntax) if desired, as they are provided by
+this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no macros.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Module Changelog:
+
+The changes to this module since its initial release are listed below, as of the
+DMBS version where the change was made.
+
+### 20160403
+Initial release.

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/doxygen.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/doxygen.mk
@@ -1,0 +1,62 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+DMBS_BUILD_MODULES         += DOXYGEN
+DMBS_BUILD_TARGETS         += doxygen doxygen-upgrade doxygen-create
+DMBS_BUILD_MANDATORY_VARS  +=
+DMBS_BUILD_OPTIONAL_VARS   += DOXYGEN_CONF DOXYGEN_FAIL_ON_WARNING DOXYGEN_OVERRIDE_PARAMS
+DMBS_BUILD_PROVIDED_VARS   +=
+DMBS_BUILD_PROVIDED_MACROS +=
+
+# Conditionally import the CORE module of DMBS if it is not already imported
+DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+ifeq ($(findstring CORE, $(DMBS_BUILD_MODULES)),)
+  include $(DMBS_MODULE_PATH)/core.mk
+endif
+
+# Default values of optionally user-supplied variables
+DOXYGEN_CONF            ?= doxyfile
+DOXYGEN_FAIL_ON_WARNING ?= Y
+DOXYGEN_OVERRIDE_PARAMS ?= QUIET=YES
+
+# Sanity check user supplied values
+$(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+$(call ERROR_IF_EMPTY, DOXYGEN_CONF)
+$(call ERROR_IF_NONBOOL, DOXYGEN_FAIL_ON_WARNING)
+
+# Output Messages
+MSG_DOXYGEN_CMD         := ' [DOXYGEN] :'
+
+# Determine Doxygen invocation command
+BASE_DOXYGEN_CMD := ( cat $(DOXYGEN_CONF) $(DOXYGEN_OVERRIDE_PARAMS:%=; echo "%") ) | doxygen -
+ifeq ($(DOXYGEN_FAIL_ON_WARNING), Y)
+   DOXYGEN_CMD := if ( $(BASE_DOXYGEN_CMD) 2>&1 | grep -v "warning: ignoring unsupported tag" ;); then exit 1; fi;
+else
+   DOXYGEN_CMD := $(BASE_DOXYGEN_CMD)
+endif
+
+# Error if the specified Doxygen configuration file does not exist
+$(DOXYGEN_CONF):
+	$(error Doxygen configuration file $@ does not exist)
+
+# Builds the project documentation using the specified configuration file and the DOXYGEN tool
+doxygen: $(DOXYGEN_CONF) $(MAKEFILE_LIST)
+	@echo $(MSG_DOXYGEN_CMD) Configuration file \"$(DOXYGEN_CONF)\" with parameters \"$(DOXYGEN_OVERRIDE_PARAMS)\"
+	$(DOXYGEN_CMD)
+
+# Upgrades an existing Doxygen configuration file to the latest Doxygen template, preserving settings
+doxygen-upgrade: $(DOXYGEN_CONF) $(MAKEFILE_LIST)
+	@echo $(MSG_DOXYGEN_CMD) Upgrading configuration file \"$(DOXYGEN_CONF)\" with latest template
+	doxygen -u $(DOXYGEN_CONF) > /dev/null
+
+# Creates a new Doxygen configuration file with the set file name
+doxygen-create: $(MAKEFILE_LIST)
+	@echo $(MSG_DOXYGEN_CMD) Creating new configuration file \"$(DOXYGEN_CONF)\" with latest template
+	doxygen -g $(DOXYGEN_CONF) > /dev/null
+
+

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/gcc.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/gcc.md
@@ -1,0 +1,211 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Module: GCC
+-----------------
+
+The GCC module provides build targets to compile a user application, using a
+variant of GCC for a specific target architecture (such as `avr-gcc`).
+
+## Importing This Module into a Makefile:
+
+To use this module in your application makefile, add the following code to your
+makefile:
+
+    include $(DMBS_PATH)/gcc.mk
+
+## Prerequisites:
+
+This module requires the GCC compiler to be installed and available in the
+system's `PATH` variable for the desired target architecture.
+
+## Build Targets:
+
+The following targets are supported by this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>size</td>
+    <td>Show the compiled binary size for the various memory segments.</td>
+   </tr>
+   <tr>
+    <td>symbol-sizes</td>
+    <td>Show the size of each symbol in the compiled binary (useful to find large functions to optimize further).</td>
+   </tr>
+   <tr>
+    <td>all</td>
+    <td>Build application and generate all binary (BIN, ELF, HEX) and auxiliary (LSS, MAP, SYM, etc.) output files.</td>
+   </tr>
+   <tr>
+    <td>lib</td>
+    <td>Generate a static `.a` library from the application code, containing the flash region's data.</td>
+   </tr>
+   <tr>
+    <td>elf</td>
+    <td>Generate an ELF debug file from the application code, containing all region's data.</td>
+   </tr>
+   <tr>
+    <td>bin</td>
+    <td>Generate a flat BIN binary file from the application code, containing the flash region's data.</td>
+   </tr>
+   <tr>
+    <td>hex</td>
+    <td>Generate a pair of Intel HEX files from the application code, containing the flash region's data (HEX) and EEPROM data (EEP).</td>
+   </tr>
+   <tr>
+    <td>lss</td>
+    <td>Generate a LSS listing file showing the disassembly of the compiled application.</td>
+   </tr>
+   <tr>
+    <td>clean</td>
+    <td>Remove all generated project intermediary and binary output files.</td>
+   </tr>
+   <tr>
+    <td>mostlyclean</td>
+    <td>Remove all generated project intermediary output files, but preserve the binary output files.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Mandatory Variables:
+
+The following variables must be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile to be able to use this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>MCU</td>
+    <td>Name of the Atmel processor model (e.g. `at90usb1287`).</td>
+   </tr>
+   <tr>
+    <td>TARGET</td>
+    <td>Name of the application output file prefix (e.g. `TestApplication`).</td>
+   </tr>
+   <tr>
+    <td>ARCH</td>
+    <td>Target device architecture (e.g. `AVR8`).</td>
+   </tr>
+   <tr>
+     <td>SRC</td>
+     <td>List of all project source files (C, C++, ASM).</td>
+   </tr>
+ </tbody>
+</table>
+
+## Optional Variables:
+
+The following variables may be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile. If not specified, a default value will
+be assumed.
+
+<table>
+ <tbody>
+   <tr>
+    <td>COMPILER_PATH</td>
+    <td>Path to the compiler to use, in case a specific compiler should be substituted for the one in the system's `PATH` variable. Default is blank (use `PATH` provided compiler).</td>
+   </tr>
+   <tr>
+    <td>OPTIMIZATION</td>
+    <td>Optimization level to use when compiling C and C++ source files. Default is `s` (optimize for smallest size).</td>
+   </tr>
+   <tr>
+    <td>C_STANDARD</td>
+    <td>C language standard used when compiling C language source files. Default is `gnu99` (C99 standard with GNU extensions)./td>
+   </tr>
+   <tr>
+    <td>CPP_STANDARD</td>
+    <td>C++ language standard used when compiling C++ language source files. Default is `gnu++98` (C++98 standard with GNU extensions)./td>
+   </tr>
+   <tr>
+    <td>F_CPU</td>
+    <td>Processor core clock frequency, in Hz. This is used by some architectures for functions such as software spin-loop delays. Default is blank (no value defined).</td>
+   </tr>
+   <tr>
+    <td>C_FLAGS</td>
+    <td>Common GCC flags passed to the compiler for C language (C) input files. Default is blank (no additional flags).</td>
+   </tr>
+   <tr>
+    <td>CPP_FLAGS</td>
+    <td>Common GCC flags passed to the compiler for C++ language (CPP) input files. Default is blank (no additional flags).</td>
+   </tr>
+   <tr>
+    <td>ASM_FLAGS</td>
+    <td>Common GCC flags passed to the assembler for assembly language (S) input files. Default is blank (no additional flags).</td>
+   </tr>
+   <tr>
+    <td>CC_FLAGS</td>
+    <td>Common GCC flags passed to the compiler for all source file types. Default is blank (no additional flags).</td>
+   </tr>
+   <tr>
+    <td>LD_FLAGS</td>
+    <td>Extra flags to pass to the GNU linker when linking the compiled object files into the resulting binary. Default is blank (no additional flags).</td>
+   </tr>
+   <tr>
+    <td>LINKER_RELAXATIONS</td>
+    <td>Boolean, if `Y` linker relaxations will be enabled to slightly reduce the resulting binary's size. Default is `Y`.</td>
+   </tr>
+   <tr>
+    <td>JUMP_TABLES</td>
+    <td>Boolean, if `Y` jump tables will be enabled to slightly reduce the resulting binary's size - note that this can cause incorrect jumps if the binary is relocated after compilation, such as for a bootloader. Default is `N`.</td>
+   </tr>
+   <tr>
+    <td>OBJDIR</td>
+    <td>Directory to store the intermediate object files, as they are generated from the source files. Default is `obj`.</td>
+   </tr>
+   <tr>
+    <td>OBJECT_FILES</td>
+    <td>List of additional `.o` object files to link into the final binary. Default is blank (no additional objects).</td>
+   </tr>
+   <tr>
+    <td>DEBUG_FORMAT</td>
+    <td>Debug ELF file format to generate. Default is `dwarf-2`.</td>
+   </tr>
+   <tr>
+    <td>DEBUG_LEVEL</td>
+    <td>Level of the debugging information to generate in the compiled object files. Debug is 2 (medium level debugging information).</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Variables:
+
+The following variables may be referenced in a user makefile (via `$(NAME)`
+syntax) if desired, as they are provided by this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Macros:
+
+The following macros may be referenced in a user makefile (via
+`$(call NAME, ARG1, ARG2, ...)` syntax) if desired, as they are provided by
+this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no macros.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Module Changelog:
+
+The changes to this module since its initial release are listed below, as of the
+DMBS version where the change was made.
+
+### 20170426
+Added `JUMP_TABLES` optional variable.
+
+### 20160403
+Initial release.

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/gcc.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/gcc.mk
@@ -1,0 +1,273 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+DMBS_BUILD_MODULES         += GCC
+DMBS_BUILD_TARGETS         += size symbol-sizes all lib elf bin hex lss clean mostlyclean
+DMBS_BUILD_MANDATORY_VARS  += TARGET ARCH MCU SRC
+DMBS_BUILD_OPTIONAL_VARS   += COMPILER_PATH OPTIMIZATION C_STANDARD CPP_STANDARD F_CPU C_FLAGS CPP_FLAGS ASM_FLAGS CC_FLAGS LD_FLAGS OBJDIR OBJECT_FILES DEBUG_TYPE DEBUG_LEVEL LINKER_RELAXATIONS JUMP_TABLES
+DMBS_BUILD_PROVIDED_VARS   +=
+DMBS_BUILD_PROVIDED_MACROS +=
+
+# Conditionally import the CORE module of DMBS if it is not already imported
+DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+ifeq ($(findstring CORE, $(DMBS_BUILD_MODULES)),)
+  include $(DMBS_MODULE_PATH)/core.mk
+endif
+
+# Default values of optionally user-supplied variables
+COMPILER_PATH      ?=
+OPTIMIZATION       ?= s
+F_CPU              ?=
+C_STANDARD         ?= gnu99
+CPP_STANDARD       ?= gnu++98
+C_FLAGS            ?=
+CPP_FLAGS          ?=
+ASM_FLAGS          ?=
+CC_FLAGS           ?=
+OBJDIR             ?= obj
+OBJECT_FILES       ?=
+DEBUG_FORMAT       ?= dwarf-2
+DEBUG_LEVEL        ?= 2
+LINKER_RELAXATIONS ?= Y
+JUMP_TABLES        ?= N
+
+# Sanity check user supplied values
+$(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+$(call ERROR_IF_EMPTY, MCU)
+$(call ERROR_IF_EMPTY, TARGET)
+$(call ERROR_IF_EMPTY, ARCH)
+$(call ERROR_IF_EMPTY, OPTIMIZATION)
+$(call ERROR_IF_EMPTY, C_STANDARD)
+$(call ERROR_IF_EMPTY, CPP_STANDARD)
+$(call ERROR_IF_EMPTY, OBJDIR)
+$(call ERROR_IF_EMPTY, DEBUG_FORMAT)
+$(call ERROR_IF_EMPTY, DEBUG_LEVEL)
+$(call ERROR_IF_NONBOOL, LINKER_RELAXATIONS)
+$(call ERROR_IF_NONBOOL, JUMP_TABLES)
+
+# Determine the utility prefix to use for the selected architecture
+ifeq ($(ARCH), AVR8)
+   CROSS        := $(COMPILER_PATH)avr
+else ifeq ($(ARCH), XMEGA)
+   CROSS        := $(COMPILER_PATH)avr
+else ifeq ($(ARCH), UC3)
+   CROSS        := $(COMPILER_PATH)avr32
+else
+   $(error Unsupported architecture "$(ARCH)")
+endif
+
+# Output Messages
+MSG_INFO_MESSAGE := ' [INFO]    :'
+MSG_COMPILE_CMD  := ' [GCC]     :'
+MSG_ASSEMBLE_CMD := ' [GAS]     :'
+MSG_NM_CMD       := ' [NM]      :'
+MSG_REMOVE_CMD   := ' [RM]      :'
+MSG_LINK_CMD     := ' [LNK]     :'
+MSG_ARCHIVE_CMD  := ' [AR]      :'
+MSG_SIZE_CMD     := ' [SIZE]    :'
+MSG_OBJCPY_CMD   := ' [OBJCPY]  :'
+MSG_OBJDMP_CMD   := ' [OBJDMP]  :'
+
+# Convert input source file list to differentiate them by type
+C_SOURCE   := $(filter %.c, $(SRC))
+CPP_SOURCE := $(filter %.cpp, $(SRC))
+ASM_SOURCE := $(filter %.S, $(SRC))
+
+# Create a list of unknown source file types, if any are found throw an error
+UNKNOWN_SOURCE := $(filter-out $(C_SOURCE) $(CPP_SOURCE) $(ASM_SOURCE), $(SRC))
+ifneq ($(UNKNOWN_SOURCE),)
+   $(error Unknown input source file formats: $(UNKNOWN_SOURCE))
+endif
+
+# Convert input source filenames into a list of required output object files
+OBJECT_FILES += $(addsuffix .o, $(basename $(SRC)))
+
+# Check if an output object file directory was specified instead of the input file location
+ifneq ($(OBJDIR),.)
+   # Prefix all the object filenames with the output object file directory path
+   OBJECT_FILES    := $(addprefix $(patsubst %/,%,$(OBJDIR))/, $(notdir $(OBJECT_FILES)))
+
+   # Check if any object file (without path) appears more than once in the object file list
+   ifneq ($(words $(sort $(OBJECT_FILES))), $(words $(OBJECT_FILES)))
+       $(error Cannot build with OBJDIR parameter set - one or more object file name is not unique)
+   endif
+
+   # Create the output object file directory if it does not exist and add it to the virtual path list
+   $(shell mkdir -p $(OBJDIR) 2> /dev/null)
+   VPATH           += $(dir $(SRC))
+endif
+
+# Create a list of dependency files from the list of object files
+DEPENDENCY_FILES := $(OBJECT_FILES:%.o=%.d)
+
+# Create a list of common flags to pass to the compiler/linker/assembler
+BASE_CC_FLAGS    := -pipe -g$(DEBUG_FORMAT) -g$(DEBUG_LEVEL)
+ifneq ($(findstring $(ARCH), AVR8 XMEGA),)
+   BASE_CC_FLAGS += -mmcu=$(MCU) -fshort-enums -fno-inline-small-functions -fpack-struct
+else ifneq ($(findstring $(ARCH), UC3),)
+   BASE_CC_FLAGS += -mpart=$(MCU:at32%=%) -masm-addr-pseudos
+endif
+BASE_CC_FLAGS += -Wall -fno-strict-aliasing -funsigned-char -funsigned-bitfields -ffunction-sections
+BASE_CC_FLAGS += -I.
+BASE_CC_FLAGS += -DARCH=ARCH_$(ARCH)
+ifneq ($(F_CPU),)
+   BASE_CC_FLAGS += -DF_CPU=$(F_CPU)UL
+endif
+ifeq ($(LINKER_RELAXATIONS), Y)
+   BASE_CC_FLAGS += -mrelax
+endif
+ifeq ($(JUMP_TABLES), N)
+   # This flag is required for bootloaders as GCC will emit invalid jump table
+   # assembly code for devices with large amounts of flash; the jump table target
+   # is extracted from FLASH without using the correct ELPM instruction, resulting
+   # in a pseudo-random jump target.
+   BASE_CC_FLAGS += -fno-jump-tables
+endif
+
+# Additional language specific compiler flags
+BASE_C_FLAGS   := -x c -O$(OPTIMIZATION) -std=$(C_STANDARD) -Wstrict-prototypes
+BASE_CPP_FLAGS := -x c++ -O$(OPTIMIZATION) -std=$(CPP_STANDARD)
+BASE_ASM_FLAGS := -x assembler-with-cpp
+
+# Create a list of flags to pass to the linker
+BASE_LD_FLAGS := -lm -Wl,-Map=$(TARGET).map,--cref -Wl,--gc-sections
+ifeq ($(LINKER_RELAXATIONS), Y)
+   BASE_LD_FLAGS += -Wl,--relax
+endif
+ifneq ($(findstring $(ARCH), AVR8 XMEGA),)
+   BASE_LD_FLAGS += -mmcu=$(MCU)
+else ifneq ($(findstring $(ARCH), UC3),)
+   BASE_LD_FLAGS += -mpart=$(MCU:at32%=%) --rodata-writable --direct-data
+endif
+
+# Determine flags to pass to the size utility based on its reported features (only invoke if size target required)
+# and on an architecture where this non-standard patch is available
+ifneq ($(ARCH), UC3)
+size: SIZE_MCU_FLAG    := $(shell $(CROSS)-size --help | grep -- --mcu > /dev/null && echo --mcu=$(MCU) )
+size: SIZE_FORMAT_FLAG := $(shell $(CROSS)-size --help | grep -- --format=.*avr > /dev/null && echo --format=avr )
+endif
+
+# Pre-build informational target, to give compiler and project name information when building
+build_begin:
+	@echo $(MSG_INFO_MESSAGE) Begin compilation of project \"$(TARGET)\"...
+	@echo ""
+	@$(CROSS)-gcc --version
+
+# Post-build informational target, to project name information when building has completed
+build_end:
+	@echo $(MSG_INFO_MESSAGE) Finished building project \"$(TARGET)\".
+
+# Prints size information of a compiled application (FLASH, RAM and EEPROM usages)
+size: $(TARGET).elf
+	@echo $(MSG_SIZE_CMD) Determining size of \"$<\"
+	@echo ""
+	$(CROSS)-size $(SIZE_MCU_FLAG) $(SIZE_FORMAT_FLAG) $<
+
+# Prints size information on the symbols within a compiled application in decimal bytes
+symbol-sizes: $(TARGET).elf
+	@echo $(MSG_NM_CMD) Extracting \"$<\" symbols with decimal byte sizes
+	$(CROSS)-nm --size-sort --demangle --radix=d $<
+
+# Cleans intermediary build files, leaving only the compiled application files
+mostlyclean:
+	@echo $(MSG_REMOVE_CMD) Removing object files of \"$(TARGET)\"
+	rm -f $(OBJECT_FILES)
+	@echo $(MSG_REMOVE_CMD) Removing dependency files of \"$(TARGET)\"
+	rm -f $(DEPENDENCY_FILES)
+
+# Cleans all build files, leaving only the original source code
+clean: mostlyclean
+	@echo $(MSG_REMOVE_CMD) Removing output files of \"$(TARGET)\"
+	rm -f $(TARGET).elf $(TARGET).hex $(TARGET).bin $(TARGET).eep $(TARGET).map $(TARGET).lss $(TARGET).sym lib$(TARGET).a
+
+# Performs a complete build of the user application and prints size information afterwards
+all: build_begin elf hex bin lss sym size build_end
+
+# Helper targets, to build a specific type of output file without having to know the project target name
+lib: lib$(TARGET).a
+elf: $(TARGET).elf
+hex: $(TARGET).hex $(TARGET).eep
+bin: $(TARGET).bin
+lss: $(TARGET).lss
+sym: $(TARGET).sym
+
+# Default target to *create* the user application's specified source files; if this rule is executed by
+# make, the input source file doesn't exist and an error needs to be presented to the user
+$(SRC):
+	$(error Source file does not exist: $@)
+
+# Compiles an input C source file and generates an assembly listing for it
+%.s: %.c $(MAKEFILE_LIST)
+	@echo $(MSG_COMPILE_CMD) Generating assembly from C file \"$(notdir $<)\"
+	$(CROSS)-gcc -S $(BASE_CC_FLAGS) $(BASE_C_FLAGS) $(CC_FLAGS) $(C_FLAGS) $< -o $@
+
+# Compiles an input C++ source file and generates an assembly listing for it
+%.s: %.cpp $(MAKEFILE_LIST)
+	@echo $(MSG_COMPILE_CMD) Generating assembly from C++ file \"$(notdir $<)\"
+	$(CROSS)-gcc -S $(BASE_CC_FLAGS) $(BASE_CPP_FLAGS) $(CC_FLAGS) $(CPP_FLAGS) $< -o $@
+
+# Compiles an input C source file and generates a linkable object file for it
+$(OBJDIR)/%.o: %.c $(MAKEFILE_LIST)
+	@echo $(MSG_COMPILE_CMD) Compiling C file \"$(notdir $<)\"
+	$(CROSS)-gcc -c $(BASE_CC_FLAGS) $(BASE_C_FLAGS) $(CC_FLAGS) $(C_FLAGS) -MMD -MP -MF $(@:%.o=%.d) $< -o $@
+
+# Compiles an input C++ source file and generates a linkable object file for it
+$(OBJDIR)/%.o: %.cpp $(MAKEFILE_LIST)
+	@echo $(MSG_COMPILE_CMD) Compiling C++ file \"$(notdir $<)\"
+	$(CROSS)-gcc -c $(BASE_CC_FLAGS) $(BASE_CPP_FLAGS) $(CC_FLAGS) $(CPP_FLAGS) -MMD -MP -MF $(@:%.o=%.d) $< -o $@
+
+# Assembles an input ASM source file and generates a linkable object file for it
+$(OBJDIR)/%.o: %.S $(MAKEFILE_LIST)
+	@echo $(MSG_ASSEMBLE_CMD) Assembling \"$(notdir $<)\"
+	$(CROSS)-gcc -c $(BASE_CC_FLAGS) $(BASE_ASM_FLAGS) $(CC_FLAGS) $(ASM_FLAGS) -MMD -MP -MF $(@:%.o=%.d) $< -o $@
+
+# Generates a library archive file from the user application, which can be linked into other applications
+.PRECIOUS  : $(OBJECT_FILES)
+.SECONDARY : %.a
+%.a: $(OBJECT_FILES)
+	@echo $(MSG_ARCHIVE_CMD) Archiving object files into \"$@\"
+	$(CROSS)-ar rcs $@ $(OBJECT_FILES)
+
+# Generates an ELF debug file from the user application, which can be further processed for FLASH and EEPROM data
+# files, or used for programming and debugging directly
+.PRECIOUS  : $(OBJECT_FILES)
+.SECONDARY : %.elf
+%.elf: $(OBJECT_FILES)
+	@echo $(MSG_LINK_CMD) Linking object files into \"$@\"
+	$(CROSS)-gcc $^ -o $@ $(BASE_LD_FLAGS) $(LD_FLAGS)
+
+# Extracts out the loadable FLASH memory data from the project ELF file, and creates an Intel HEX format file of it
+%.hex: %.elf
+	@echo $(MSG_OBJCPY_CMD) Extracting HEX file data from \"$<\"
+	$(CROSS)-objcopy -O ihex -R .eeprom -R .fuse -R .lock -R .signature $< $@
+
+# Extracts out the loadable FLASH memory data from the project ELF file, and creates an Binary format file of it
+%.bin: %.elf
+	@echo $(MSG_OBJCPY_CMD) Extracting BIN file data from \"$<\"
+	$(CROSS)-objcopy -O binary -R .eeprom -R .fuse -R .lock -R .signature $< $@
+
+# Extracts out the loadable EEPROM memory data from the project ELF file, and creates an Intel HEX format file of it
+%.eep: %.elf
+	@echo $(MSG_OBJCPY_CMD) Extracting EEP file data from \"$<\"
+	$(CROSS)-objcopy -O ihex -j .eeprom --set-section-flags=.eeprom="alloc,load" --change-section-lma .eeprom=0 --no-change-warnings $< $@ || exit 0
+
+# Creates an assembly listing file from an input project ELF file, containing interleaved assembly and source data
+%.lss: %.elf
+	@echo $(MSG_OBJDMP_CMD) Extracting LSS file data from \"$<\"
+	$(CROSS)-objdump -h -d -S -z $< > $@
+
+# Creates a symbol file listing the loadable and discarded symbols from an input project ELF file
+%.sym: %.elf
+	@echo $(MSG_NM_CMD) Extracting SYM file data from \"$<\"
+	$(CROSS)-nm -n $< > $@
+
+# Include build dependency files
+-include $(DEPENDENCY_FILES)
+
+# Phony build targets for this module
+.PHONY: build_begin build_end $(DMBS_BUILD_TARGETS)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/hid.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/hid.md
@@ -1,0 +1,129 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Module: HID
+-----------------
+
+The HID module provides build targets to program a target running a PJRC Teensy
+or LUFA compatible HID class bootloader.
+
+## Importing This Module into a Makefile:
+
+To use this module in your application makefile, add the following code to your
+makefile:
+
+    include $(DMBS_PATH)/hid.mk
+
+## Prerequisites:
+
+This module requires the `teensy_loader_cli` utility to be available in your
+system's `PATH` variable. The `teensy_loader_cli` utility is distributed in
+a modified form (from PJRC) in the LUFA project's
+[official site](http://www.lufa-lib.org/), but is also
+made available in its original form directly from the 
+[PJRC website](https://www.pjrc.com/teensy/loader_cli.html). Note that the
+original tool works with Teensy boards only, and not LUFA HID bootloader
+devices.
+
+This module requires the `hid_bootloader_cli` utility to be available in your
+system's `PATH` variable. The `hid_bootloader_cli` Python script utility is
+distributed in LUFA project's [official site](http://www.lufa-lib.org/).
+
+This module requires the AVR-GCC compiler to be installed and available in the
+system's `PATH` variable.
+
+## Build Targets:
+
+The following targets are supported by this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>hid</td>
+    <td>Program a LUFA HID class bootloader device, using the `hid_bootloader_cli.py` Python script.</td>
+   </tr>
+   <tr>
+    <td>hid-ee</td>
+    <td>Program a LUFA HID class bootloader device's EEPROM, using the `hid_bootloader_cli.py` Python script and a shim application which is programmed into the target's flash.</td>
+   </tr>
+   <tr>
+    <td>teensy</td>
+    <td>Program a LUFA HID class bootloader device or Teensy board, using the `teensy_loader_cli` tool.</td>
+   </tr>
+   <tr>
+    <td>teensy-ee</td>
+    <td>Program a LUFA HID class bootloader device's EEPROM, using the `teensy_loader_cli` tool and a shim application which is programmed into the target's flash.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Mandatory Variables:
+
+The following variables must be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile to be able to use this module:
+
+<table>
+ <tbody>
+   <tr>
+    <td>MCU</td>
+    <td>Name of the Atmel processor model (e.g. `at90usb1287`).</td>
+   </tr>
+   <tr>
+    <td>TARGET</td>
+    <td>Name of the application output file prefix (e.g. `TestApplication`).</td>
+   </tr>   
+ </tbody>
+</table>
+
+## Optional Variables:
+
+The following variables may be defined (with a `NAME = VALUE` syntax, one
+variable per line) in the user makefile. If not specified, a default value will
+be assumed.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module has no optional variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Variables:
+
+The following variables may be referenced in a user makefile (via `$(NAME)`
+syntax) if desired, as they are provided by this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no variables.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Provided Macros:
+
+The following macros may be referenced in a user makefile (via
+`$(call NAME, ARG1, ARG2, ...)` syntax) if desired, as they are provided by
+this module.
+
+<table>
+ <tbody>
+   <tr>
+    <td>N/A</td>
+    <td>This module provides no macros.</td>
+   </tr>
+ </tbody>
+</table>
+
+## Module Changelog:
+
+The changes to this module since its initial release are listed below, as of the
+DMBS version where the change was made.
+
+### 20160403
+Initial release.

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/hid.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/DMBS/hid.mk
@@ -1,0 +1,57 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+DMBS_BUILD_MODULES         += HID
+DMBS_BUILD_TARGETS         += hid hid-ee teensy teensy-ee
+DMBS_BUILD_MANDATORY_VARS  += MCU TARGET
+DMBS_BUILD_OPTIONAL_VARS   +=
+DMBS_BUILD_PROVIDED_VARS   +=
+DMBS_BUILD_PROVIDED_MACROS +=
+
+# Conditionally import the CORE module of DMBS if it is not already imported
+DMBS_MODULE_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
+ifeq ($(findstring CORE, $(DMBS_BUILD_MODULES)),)
+  include $(DMBS_MODULE_PATH)/core.mk
+endif
+
+# Sanity-check values of mandatory user-supplied variables
+$(foreach MANDATORY_VAR, $(DMBS_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+$(call ERROR_IF_EMPTY, MCU)
+$(call ERROR_IF_EMPTY, TARGET)
+
+# Output Messages
+MSG_HID_BOOTLOADER_CMD := ' [HID]     :'
+MSG_OBJCPY_CMD         := ' [OBJCPY]  :'
+MSG_MAKE_CMD           := ' [MAKE]    :'
+
+# Programs in the target FLASH memory using the HID_BOOTLOADER_CLI tool
+hid: $(TARGET).hex $(MAKEFILE_LIST)
+	@echo $(MSG_HID_BOOTLOADER_CMD) Programming FLASH with hid_bootloader_cli using \"$<\"
+	hid_bootloader_cli -mmcu=$(MCU) -v $<
+
+# Programs in the target EEPROM memory using the HID_BOOTLOADER_CLI tool (note: clears target FLASH memory)
+hid-ee: $(TARGET).eep $(MAKEFILE_LIST)
+	@echo $(MSG_OBJCPY_CMD) Converting \"$<\" to a binary file \"InputEEData.bin\"
+	avr-objcopy -I ihex -O binary $< $(DMBS_MODULE_PATH)/HID_EEPROM_Loader/InputEEData.bin
+	@echo $(MSG_MAKE_CMD) Making EEPROM loader application for \"$<\"
+	$(MAKE) -C $(DMBS_MODULE_PATH)/HID_EEPROM_Loader/ MCU=$(MCU) clean hid
+
+# Programs in the target FLASH memory using the TEENSY_BOOTLOADER_CLI tool
+teensy: $(TARGET).hex $(MAKEFILE_LIST)
+	@echo $(MSG_HID_BOOTLOADER_CMD) Programming FLASH with teensy_loader_cli using \"$<\"
+	teensy_loader_cli -mmcu=$(MCU) -v $<
+
+# Programs in the target EEPROM memory using the TEENSY_BOOTLOADER_CLI tool (note: clears target FLASH memory)
+teensy-ee: $(TARGET).hex $(MAKEFILE_LIST)
+	@echo $(MSG_OBJCPY_CMD) Converting \"$<\" to a binary file \"InputEEData.bin\"
+	avr-objcopy -I ihex -O binary $< $(DMBS_MODULE_PATH)/HID_EEPROM_Loader/InputEEData.bin
+	@echo $(MSG_MAKE_CMD) Making EEPROM loader application for \"$<\"
+	$(MAKE) -s -C $(DMBS_MODULE_PATH)/HID_EEPROM_Loader/ MCU=$(MCU) clean teensy
+
+# Phony build targets for this module
+.PHONY: $(DMBS_BUILD_TARGETS)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/Readme.md
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/Readme.md
@@ -1,0 +1,123 @@
+DMBS - Dean's Makefile Build System
+===================================
+
+
+Project Overview
+----------------
+
+GNU Make is scary, and it's tough to get the rules right sometimes. Many
+projects get by via simple copy-pasting of old makefiles, resulting in many
+redundant copies of the same old rules. DMBS aims to solve this by providing a
+simple modular set of makefiles which can be included by your project to quickly
+add various build functionality.
+
+This aims to replace the old WinAVR "mfile" makefile template, giving better
+functionality and much simpler user makefiles.
+
+
+Benefits:
+----------------
+
+Apart from much simpler, cleaner makefiles DMBS carries the aim of making the
+process of troubleshooting build issues a little easier. Lots can go wrong, so
+DMBS tries to sanity check its inputs wherever possible, and produce
+human-readable error messages. Forgotten to set a variable? Get a
+`Makefile {X} value not set.` message, rather than a possibly unrelated message.
+Have the wrong filename? See `Source file does not exist: {X}` rather than the
+infamous `No rule to make target {X}` message.
+
+
+Use:
+----------------
+
+A template user makefile is provided in the `Template` directory. DMBS modules
+are included via a GNU Make `include` directive. While the DMBS `core` module is
+always required, you can pick and choose what other modules you wish to add to
+your user project.
+
+[See here for the documentation on the individual modules provided by DMBS.](DMBS/ModulesOverview.md)
+If you're interested in writing your own DMBS module(s), [see here.](DMBS/WritingYourOwnModules.md)
+
+Here's an example user makefile:
+
+	MCU          = atmega128
+	ARCH         = AVR8
+	F_CPU        = 8000000
+	OPTIMIZATION = s
+	TARGET       = Template
+	SRC          = $(TARGET).c
+	CC_FLAGS     =
+	LD_FLAGS     =
+
+	# Default target
+	all:
+
+	# Include DMBS build script makefiles
+	DMBS_PATH   ?= ../DMBS
+	include $(DMBS_PATH)/core.mk
+	include $(DMBS_PATH)/gcc.mk
+	include $(DMBS_PATH)/cppcheck.mk
+	include $(DMBS_PATH)/doxygen.mk
+	include $(DMBS_PATH)/dfu.mk
+	include $(DMBS_PATH)/hid.mk
+	include $(DMBS_PATH)/avrdude.mk
+	include $(DMBS_PATH)/atprogram.mk
+
+Each DMBS module can optionally supply one or more Make variables and macros,
+which you can reference in your user makefile. Additionally, modules can require
+one or more variables to be set by the user makefile, with (in some cases) sane
+defaults used if left out.
+
+As modules are added, you can get a list of available targets by simply typing
+`make help` from the command line. This will produce a formatted list of targets
+as well as mandatory and optional variables and exposed variables and macros.
+
+
+Distribution
+----------------
+
+You can embed DMBS in your project any way you like - some options are:
+1. A git submodule
+2. A source tarball
+3. A manually copied extracted archive
+
+The intention of DMBS is that users can just import it from whatever source
+they like. If your project needs to extend the existing modules in an unusual
+manner, or if you want to provide your own modules, you can include them in
+your project repository (or submit a patch to DMBS if your module is generic
+enough to warrant wide use).
+
+
+License
+----------------
+
+DMBS is released into the public domain, making is suitable for use everywhere,
+by everyone. Contributions are greatly appreciated however, in order to make
+DMBS better for everyone.
+
+The actual license text is as follows:
+
+	This is free and unencumbered software released into the public domain.
+
+	Anyone is free to copy, modify, publish, use, compile, sell, or
+	distribute this software, either in source code form or as a compiled
+	binary, for any purpose, commercial or non-commercial, and by any
+	means.
+
+	In jurisdictions that recognize copyright laws, the author or authors
+	of this software dedicate any and all copyright interest in the
+	software to the public domain. We make this dedication for the benefit
+	of the public at large and to the detriment of our heirs and
+	successors. We intend this dedication to be an overt act of
+	relinquishment in perpetuity of all present and future rights to this
+	software under copyright law.
+
+	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+	EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+	MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+	IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+	OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+	ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+	OTHER DEALINGS IN THE SOFTWARE.
+
+	For more information, please refer to <http://unlicense.org/>

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/Template/Template.c
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/Template/Template.c
@@ -1,0 +1,12 @@
+/*
+             DMBS Build System
+      Released into the public domain.
+
+   dean [at] fourwalledcubicle [dot] com
+         www.fourwalledcubicle.com
+ */
+
+int main(void)
+{
+	// Application code here.
+}

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/Template/makefile
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/DMBS/Template/makefile
@@ -1,0 +1,32 @@
+#
+#            DMBS Build System
+#     Released into the public domain.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#        www.fourwalledcubicle.com
+#
+
+# Run "make help" for target help.
+
+MCU          = atmega128
+ARCH         = AVR8
+F_CPU        = 8000000
+OPTIMIZATION = s
+TARGET       = Template
+SRC          = $(TARGET).c
+CC_FLAGS     =
+LD_FLAGS     =
+
+# Default target
+all:
+
+# Include DMBS build script makefiles
+DMBS_PATH   ?= ../DMBS
+include $(DMBS_PATH)/core.mk
+include $(DMBS_PATH)/gcc.mk
+include $(DMBS_PATH)/cppcheck.mk
+include $(DMBS_PATH)/doxygen.mk
+include $(DMBS_PATH)/dfu.mk
+include $(DMBS_PATH)/hid.mk
+include $(DMBS_PATH)/avrdude.mk
+include $(DMBS_PATH)/atprogram.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/LUFA/lufa-gcc.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/LUFA/lufa-gcc.mk
@@ -1,0 +1,43 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_BUILD_MODULES         += LUFA_GCC
+DMBS_BUILD_TARGETS         +=
+DMBS_BUILD_MANDATORY_VARS  += LUFA_PATH ARCH F_USB
+DMBS_BUILD_OPTIONAL_VARS   += BOARD
+DMBS_BUILD_PROVIDED_VARS   +=
+DMBS_BUILD_PROVIDED_MACROS +=
+
+SHELL = /bin/sh
+
+ERROR_IF_UNSET   ?= $(if $(filter undefined, $(origin $(strip $(1)))), $(error Makefile $(strip $(1)) value not set))
+ERROR_IF_EMPTY   ?= $(if $(strip $($(strip $(1)))), , $(error Makefile $(strip $(1)) option cannot be blank))
+ERROR_IF_NONBOOL ?= $(if $(filter Y N, $($(strip $(1)))), , $(error Makefile $(strip $(1)) option must be Y or N))
+
+# Sanity check user supplied values
+$(call ERROR_IF_EMPTY, LUFA_PATH)
+$(call ERROR_IF_EMPTY, ARCH)
+$(call ERROR_IF_EMPTY, F_USB)
+
+# Default values of optionally user-supplied variables
+BOARD ?= NONE
+
+# Determine the utility prefix to use for the selected architecture
+ifeq ($(ARCH), XMEGA)
+   $(warning The XMEGA device support is currently EXPERIMENTAL (incomplete and/or non-functional), and is included for preview purposes only.)
+else ifeq ($(ARCH), UC3)
+   $(warning The UC3 device support is currently EXPERIMENTAL (incomplete and/or non-functional), and is included for preview purposes only.)
+endif
+
+# Common LUFA C/C++ includes/definitions
+LUFA_CXX_INCLUDES = -I. -I$(patsubst %/,%,$(LUFA_PATH))/..
+LUFA_CXX_DEFINES  = -DARCH=ARCH_$(ARCH) -DBOARD=BOARD_$(BOARD) -DF_USB=$(F_USB)UL
+
+# LUFA specific standard build options
+C_FLAGS   += $(LUFA_CXX_INCLUDES) $(LUFA_CXX_DEFINES) $(LUFA_CXX_FLAGS)
+CPP_FLAGS += $(LUFA_CXX_INCLUDES) $(LUFA_CXX_DEFINES) $(LUFA_CXX_FLAGS)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/LUFA/lufa-sources.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/LUFA/lufa-sources.mk
@@ -1,0 +1,95 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_BUILD_MODULES         += LUFA_SOURCES
+DMBS_BUILD_TARGETS         +=
+DMBS_BUILD_MANDATORY_VARS  += LUFA_PATH ARCH
+DMBS_BUILD_OPTIONAL_VARS   +=
+DMBS_BUILD_PROVIDED_VARS   += LUFA_SRC_USB_DEVICE LUFA_SRC_USB_HOST    \
+                              LUFA_SRC_USB LUFA_SRC_USBCLASS_DEVICE    \
+                              LUFA_SRC_USBCLASS_HOST LUFA_SRC_USBCLASS \
+                              LUFA_SRC_TEMPERATURE LUFA_SRC_SERIAL     \
+                              LUFA_SRC_TWI LUFA_SRC_PLATFORM
+DMBS_BUILD_PROVIDED_MACROS +=
+
+SHELL = /bin/sh
+
+ERROR_IF_UNSET   ?= $(if $(filter undefined, $(origin $(strip $(1)))), $(error Makefile $(strip $(1)) value not set))
+ERROR_IF_EMPTY   ?= $(if $(strip $($(strip $(1)))), , $(error Makefile $(strip $(1)) option cannot be blank))
+ERROR_IF_NONBOOL ?= $(if $(filter Y N, $($(strip $(1)))), , $(error Makefile $(strip $(1)) option must be Y or N))
+
+# Sanity check user supplied values
+$(foreach MANDATORY_VAR, $(LUFA_BUILD_MANDATORY_VARS), $(call ERROR_IF_UNSET, $(MANDATORY_VAR)))
+$(call ERROR_IF_EMPTY, LUFA_PATH)
+$(call ERROR_IF_EMPTY, ARCH)
+
+# Allow LUFA_ROOT_PATH to be overridden elsewhere to support legacy LUFA makefiles
+LUFA_ROOT_PATH ?= $(patsubst %/,%,$(LUFA_PATH))
+
+# Construct LUFA module source variables
+LUFA_SRC_USB_COMMON      := $(LUFA_ROOT_PATH)/Drivers/USB/Core/$(ARCH)/USBController_$(ARCH).c   \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/$(ARCH)/USBInterrupt_$(ARCH).c    \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/ConfigDescriptors.c               \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/Events.c                          \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/USBTask.c                         \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Common/HIDParser.c               \
+
+LUFA_SRC_USB_HOST        := $(LUFA_ROOT_PATH)/Drivers/USB/Core/$(ARCH)/Host_$(ARCH).c            \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/$(ARCH)/Pipe_$(ARCH).c            \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/$(ARCH)/PipeStream_$(ARCH).c      \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/HostStandardReq.c                 \
+                            $(LUFA_SRC_USB_COMMON)
+
+LUFA_SRC_USB_DEVICE      := $(LUFA_ROOT_PATH)/Drivers/USB/Core/$(ARCH)/Device_$(ARCH).c          \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/$(ARCH)/Endpoint_$(ARCH).c        \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/$(ARCH)/EndpointStream_$(ARCH).c  \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Core/DeviceStandardReq.c               \
+                            $(LUFA_SRC_USB_COMMON)
+
+LUFA_SRC_USBCLASS_DEVICE := $(LUFA_ROOT_PATH)/Drivers/USB/Class/Device/AudioClassDevice.c        \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Device/CDCClassDevice.c          \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Device/HIDClassDevice.c          \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Device/MassStorageClassDevice.c  \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Device/MIDIClassDevice.c         \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Device/PrinterClassDevice.c      \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Device/RNDISClassDevice.c        \
+
+LUFA_SRC_USBCLASS_HOST   := $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/AndroidAccessoryClassHost.c \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/AudioClassHost.c            \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/CDCClassHost.c              \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/HIDClassHost.c              \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/MassStorageClassHost.c      \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/MIDIClassHost.c             \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/PrinterClassHost.c          \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/RNDISClassHost.c            \
+                            $(LUFA_ROOT_PATH)/Drivers/USB/Class/Host/StillImageClassHost.c
+
+LUFA_SRC_USB             := $(sort $(LUFA_SRC_USB_COMMON) $(LUFA_SRC_USB_HOST) $(LUFA_SRC_USB_DEVICE))
+
+LUFA_SRC_USBCLASS        := $(LUFA_SRC_USBCLASS_DEVICE) $(LUFA_SRC_USBCLASS_HOST)
+
+LUFA_SRC_TEMPERATURE     := $(LUFA_ROOT_PATH)/Drivers/Board/Temperature.c
+
+LUFA_SRC_SERIAL          := $(LUFA_ROOT_PATH)/Drivers/Peripheral/$(ARCH)/Serial_$(ARCH).c
+
+LUFA_SRC_TWI             := $(LUFA_ROOT_PATH)/Drivers/Peripheral/$(ARCH)/TWI_$(ARCH).c
+
+ifeq ($(ARCH), UC3)
+   LUFA_SRC_PLATFORM     := $(LUFA_ROOT_PATH)/Platform/UC3/Exception.S   \
+                            $(LUFA_ROOT_PATH)/Platform/UC3/InterruptManagement.c
+else
+   LUFA_SRC_PLATFORM     :=
+endif
+
+# Build a list of all available module sources
+LUFA_SRC_ALL_FILES   := $(LUFA_SRC_USB)            \
+                        $(LUFA_SRC_USBCLASS)       \
+                        $(LUFA_SRC_TEMPERATURE)    \
+                        $(LUFA_SRC_SERIAL)         \
+                        $(LUFA_SRC_TWI)            \
+                        $(LUFA_SRC_PLATFORM)

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_atprogram.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_atprogram.mk
@@ -1,0 +1,10 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_PATH := $(LUFA_PATH)/Build/DMBS/DMBS
+include $(DMBS_PATH)/atprogram.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_avrdude.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_avrdude.mk
@@ -1,0 +1,10 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_PATH := $(LUFA_PATH)/Build/DMBS/DMBS
+include $(DMBS_PATH)/avrdude.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_build.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_build.mk
@@ -1,0 +1,12 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_PATH      ?= $(LUFA_PATH)/Build/DMBS/DMBS
+DMBS_LUFA_PATH ?= $(LUFA_PATH)/Build/LUFA
+include $(DMBS_PATH)/gcc.mk
+include $(DMBS_LUFA_PATH)/lufa-gcc.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_core.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_core.mk
@@ -1,0 +1,10 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_PATH := $(LUFA_PATH)/Build/DMBS/DMBS
+include $(DMBS_PATH)/core.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_cppcheck.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_cppcheck.mk
@@ -1,0 +1,10 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_PATH := $(LUFA_PATH)/Build/DMBS/DMBS
+include $(DMBS_PATH)/cppcheck.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_dfu.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_dfu.mk
@@ -1,0 +1,10 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_PATH := $(LUFA_PATH)/Build/DMBS/DMBS
+include $(DMBS_PATH)/dfu.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_doxygen.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_doxygen.mk
@@ -1,0 +1,10 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_PATH := $(LUFA_PATH)/Build/DMBS/DMBS
+include $(DMBS_PATH)/doxygen.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_hid.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_hid.mk
@@ -1,0 +1,10 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_PATH := $(LUFA_PATH)/Build/DMBS/DMBS
+include $(DMBS_PATH)/hid.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_sources.mk
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/Build/lufa_sources.mk
@@ -1,0 +1,10 @@
+#
+#             LUFA Library
+#     Copyright (C) Dean Camera, 2015.
+#
+#  dean [at] fourwalledcubicle [dot] com
+#           www.lufa-lib.org
+#
+
+DMBS_LUFA_PATH ?= $(LUFA_PATH)/Build/LUFA
+include $(DMBS_LUFA_PATH)/lufa-sources.mk

--- a/Firmware/Chameleon-Mini/src/LUFA/LUFA/License.txt
+++ b/Firmware/Chameleon-Mini/src/LUFA/LUFA/License.txt
@@ -1,0 +1,24 @@
+                  LUFA Library
+        Copyright (C) Dean Camera, 2017.
+
+     dean [at] fourwalledcubicle [dot] com
+                www.lufa-lib.org
+
+
+Permission to use, copy, modify, and distribute this software
+and its documentation for any purpose is hereby granted without
+fee, provided that the above copyright notice appear in all
+copies and that both that the copyright notice and this
+permission notice and warranty disclaimer appear in supporting
+documentation, and that the name of the author not be used in
+advertising or publicity pertaining to distribution of the
+software without specific, written prior permission.
+
+The author disclaims all warranties with regard to this
+software, including all implied warranties of merchantability
+and fitness.  In no event shall the author be liable for any
+special, indirect or consequential damages or any damages
+whatsoever resulting from loss of use, data or profits, whether
+in an action of contract, negligence or other tortious action,
+arising out of or in connection with the use or performance of
+this software.


### PR DESCRIPTION
I have added the needed LUFA files and fixed the variable LUFA_PATH in makefile.
Now it still gives errors but at least they are related to the project itself :-P
```
src/LUFA/LUFA/Build/LUFA/lufa-gcc.mk:32: The XMEGA device support is currently EXPERIMENTAL (incomplete and/or non-functional), and is included for preview purposes only.
 [INFO]    : Begin compilation of project "Chameleon-Mini"...

avr-gcc (GCC) 5.4.0
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

 [GCC]     : Compiling C file "Chameleon-Mini.c"
avr-gcc -c -pipe -gdwarf-2 -g2 -mmcu=atxmega32a4u -fshort-enums -fno-inline-small-functions -fpack-struct -Wall -fno-strict-aliasing -funsigned-char -funsigned-bitfields -ffunction-sections -I. -DARCH=ARCH_XMEGA -DF_CPU=32000000UL -mrelax -fno-jump-tables -x c -Os -std=gnu99 -Wstrict-prototypes -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=0x10000  -DFLASH_DATA_SIZE=0x10000  -DSPM_HELPER_ADDR=0x21FE0  -DBUILD_DATE=\"171128\" -DCOMMIT_ID=\"a46482a\" -DCONFIG_MF_CLASSIC_1K_SUPPORT -DCONFIG_MF_CLASSIC_1K_7B_SUPPORT -DCONFIG_MF_CLASSIC_4K_SUPPORT -DCONFIG_MF_CLASSIC_4K_7B_SUPPORT -DCONFIG_MF_ULTRALIGHT_SUPPORT  -DCONFIG_ISO14443A_SNIFF_SUPPORT -DCONFIG_ISO14443A_READER_SUPPORT -DSUPPORT_MF_CLASSIC_MAGIC_MODE -DSUPPORT_UID7_FIX_MANUFACTURER_BYTE -DSUPPORT_FIRMWARE_UPGRADE -DDEFAULT_CONFIGURATION=CONFIG_NONE -DDEFAULT_RBUTTON_ACTION=BUTTON_ACTION_CYCLE_SETTINGS -DDEFAULT_LBUTTON_ACTION=BUTTON_ACTION_RECALL_MEM -DBUTTON_SETTING_GLOBAL -DDEFAULT_RED_LED_ACTION=LED_SETTING_CHANGE -DDEFAULT_GREEN_LED_ACTION=LED_POWERED -DLED_SETTING_GLOBAL -DDEFAULT_LOG_MODE=LOG_MODE_OFF -DLOG_SETTING_GLOBAL -DDEFAULT_SETTING=SETTINGS_FIRST -DDEFAULT_PENDING_TASK_TIMEOUT=50  -DENABLE_EEPROM_SETTINGS  -I. -Isrc/LUFA/LUFA/.. -DARCH=ARCH_XMEGA -DBOARD=BOARD_NONE -DF_USB=48000000UL  -MMD -MP -MF Bin/Chameleon-Mini.d Chameleon-Mini.c -o Bin/Chameleon-Mini.o
In file included from Chameleon-Mini.h:17:0,
                 from Chameleon-Mini.c:1:
Application/Application.h: In function ‘ApplicationTick’:
Application/Application.h:30:24: error: ‘ConfigurationType {aka struct <anonymous>}’ has no member named ‘ApplicationTickFunc’
     ActiveConfiguration.ApplicationTickFunc();
                        ^
Chameleon-Mini.c: In function ‘ComPasssimple’:
Chameleon-Mini.c:3:33: warning: suggest parentheses around arithmetic in operand of ‘^’ [-Wparentheses]
 #define genFun(size, key, i) key+i
                                 ^
Chameleon-Mini.c:11:7: note: in expansion of macro ‘genFun’
   t = genFun(len, key, i) ^ s;  // ����
       ^
Chameleon-Mini.c: In function ‘main’:
Chameleon-Mini.c:135:24: warning: passing argument 1 of ‘eeprom_read_byte’ makes pointer from integer without a cast [-Wint-conversion]
    if(eeprom_read_byte(33)!=0x55)
                        ^
In file included from Terminal/../src/LUFA/LUFA/Drivers/USB/../../Common/Common.h:130:0,
                 from Terminal/../src/LUFA/LUFA/Drivers/USB/USB.h:382,
                 from Terminal/Terminal.h:12,
                 from Chameleon-Mini.h:15,
                 from Chameleon-Mini.c:1:
/usr/lib/avr/include/avr/eeprom.h:137:9: note: expected ‘const uint8_t * {aka const unsigned char *}’ but argument is of type ‘int’
 uint8_t eeprom_read_byte (const uint8_t *__p) __ATTR_PURE__;
         ^
Chameleon-Mini.c:139:23: warning: passing argument 1 of ‘eeprom_write_byte’ makes pointer from integer without a cast [-Wint-conversion]
     eeprom_write_byte(33,0x55);
                       ^
In file included from Terminal/../src/LUFA/LUFA/Drivers/USB/../../Common/Common.h:130:0,
                 from Terminal/../src/LUFA/LUFA/Drivers/USB/USB.h:382,
                 from Terminal/Terminal.h:12,
                 from Chameleon-Mini.h:15,
                 from Chameleon-Mini.c:1:
/usr/lib/avr/include/avr/eeprom.h:164:6: note: expected ‘uint8_t * {aka unsigned char *}’ but argument is of type ‘int’
 void eeprom_write_byte (uint8_t *__p, uint8_t __value);
      ^
Chameleon-Mini.c:144:23: warning: integer overflow in expression [-Woverflow]
     Read_Save(temp, 32*1024,sizeof(SettingsType)+2);
                       ^
<command-line>:0:17: error: ‘SETTINGS_FIRST’ undeclared (first use in this function)
Chameleon-Mini.c:154:22: note: in expansion of macro ‘DEFAULT_SETTING’
     .ActiveSetting = DEFAULT_SETTING,
                      ^
<command-line>:0:17: note: each undeclared identifier is reported only once for each function it appears in
Chameleon-Mini.c:154:22: note: in expansion of macro ‘DEFAULT_SETTING’
     .ActiveSetting = DEFAULT_SETTING,
                      ^
Chameleon-Mini.c:159:22: error: ‘DEFAULT_BUTTON_ACTION’ undeclared (first use in this function)
      .ButtonAction = DEFAULT_BUTTON_ACTION,
                      ^
src/LUFA/LUFA/Build/DMBS/DMBS/gcc.mk:216: recipe for target 'Bin/Chameleon-Mini.o' failed
make: *** [Bin/Chameleon-Mini.o] Error 1
```