### PR TITLE
Add SPI_FLASH_INFOMY command

### DIFF
--- a/Firmware/Chameleon-Mini/Memory.c
+++ b/Firmware/Chameleon-Mini/Memory.c
@@ -20,6 +20,7 @@
 #define FLASH_CMD_BUF1_TO_MEM_ERASE		0x83
 #define FLASH_CMD_BUF2_TO_MEM_ERASE		0x86
 #define FLASH_CMD_PAGE_ERASE			0x81
+#define FLASH_CMD_READMANUFDEVICEINFO   0x9F
 
 #define FLASH_STATUS_REG_READY_BIT		(1<<7)
 #define FLASH_STATUS_REG_COMP_BIT		(1<<6)
@@ -163,6 +164,15 @@ INLINE void FlashClearPage(uint16_t PageAddress) {
 	SPITransferByte( (PageAddress >> 8) & 0xFF );
 	SPITransferByte( (PageAddress >> 0) & 0xFF );
 	SPITransferByte( 0 );
+	MEMORY_FLASH_PORT.OUTSET = MEMORY_FLASH_CS;
+}
+
+void FlashReadManufacturerDeviceInfo(void* Buffer) {
+	while(FlashIsBusy());
+
+	MEMORY_FLASH_PORT.OUTCLR = MEMORY_FLASH_CS;
+	SPITransferByte(FLASH_CMD_READMANUFDEVICEINFO);
+	SPIReadBlock(Buffer, 4);
 	MEMORY_FLASH_PORT.OUTSET = MEMORY_FLASH_CS;
 }
 

--- a/Firmware/Chameleon-Mini/Memory.h
+++ b/Firmware/Chameleon-Mini/Memory.h
@@ -23,6 +23,8 @@
 #define MEMORY_SIZE_PER_SETTING_4K	4096
 #define MEMORY_SIZE_PER_SETTING_1K	1024
 
+void FlashReadManufacturerDeviceInfo(void* Buffer);
+
 void MemoryInit(void);
 void MemoryReadBlock(void* Buffer, uint16_t Address, uint16_t ByteCount);
 void MemoryWriteBlock(const void* Buffer, uint16_t Address, uint16_t ByteCount);

--- a/Firmware/Chameleon-Mini/Terminal/CommandLine.c
+++ b/Firmware/Chameleon-Mini/Terminal/CommandLine.c
@@ -316,6 +316,12 @@ const PROGMEM CommandEntryType CommandTable[] = {
 	  .GetFunc    = CommandGetDetection,
   },
 #endif
+  {
+	  .Command    = COMMAND_SPI_FLASH_INFO,
+	  .ExecFunc   = CommandExecSPIFlashInfo,
+	  .SetFunc    = NO_FUNCTION,
+	  .GetFunc    = CommandGetSPIFlashInfo,
+  },
   { /* This has to be last element */
     .Command    = COMMAND_LIST_END,
     .ExecFunc   = NO_FUNCTION,

--- a/Firmware/Chameleon-Mini/Terminal/Commands.c
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.c
@@ -337,3 +337,32 @@ CommandStatusIdType CommandGetUltralightPassword(char* OutParam) {
 	 return COMMAND_INFO_OK_ID;
  }
 #endif
+
+CommandStatusIdType CommandExecSPIFlashInfo(char* OutMessage)
+{
+	uint8_t b[4];
+	FlashReadManufacturerDeviceInfo(b);
+	uint8_t ManufacturerId = b[0];
+	uint8_t FamilyCode = b[1] >> 5;
+	uint8_t DensityCode = b[1] & 0x1F;
+	uint8_t MLC_Code = b[2] >> 5;
+	uint8_t ProductVersionCode = b[2] & 0x1F;
+	uint16_t Mbits = 0;
+	if ((DensityCode >= 2) && (DensityCode <= 8) && (FamilyCode == 1))
+		Mbits = 1 << (DensityCode - 2); 
+	// Minimum: AT45DB011D Density Code : 00010 = 1-Mbit 
+	// Maximum: AT45DB642D Density Code : 01000 = 64-Mbit
+	snprintf_P(OutMessage, TERMINAL_BUFFER_SIZE, 
+		PSTR("Manufacturer ID: %02xh\r\nFamily code: %d\r\nDensity code: %d\r\nMLC Code: %d\r\nProduct version: %d\r\nFlash memory size: %d-Mbit (%d-KByte)"), 
+		ManufacturerId, FamilyCode, DensityCode, MLC_Code, ProductVersionCode, Mbits, Mbits * 128); 
+		// Precalculated 1024 / 8 = 128, to prevent uint16_t overflow for possible 64-Mbit flash
+	return COMMAND_INFO_OK_WITH_TEXT_ID;
+}
+
+CommandStatusIdType CommandGetSPIFlashInfo(char* OutParam)
+{
+	uint8_t b[4];
+	FlashReadManufacturerDeviceInfo(b);
+	snprintf_P(OutParam, TERMINAL_BUFFER_SIZE, PSTR("%02x%02x%02x%02x"), b[0], b[1], b[2], b[3]);
+	return COMMAND_INFO_OK_WITH_TEXT_ID;
+}

--- a/Firmware/Chameleon-Mini/Terminal/Commands.h
+++ b/Firmware/Chameleon-Mini/Terminal/Commands.h
@@ -167,6 +167,10 @@ CommandStatusIdType CommandGetDetection(char* OutParam);
 CommandStatusIdType CommandSetDetection(char* OutMessage, const char* InParam);
 #endif
 
+#define COMMAND_SPI_FLASH_INFO  "SPI_FLASH_INFOMY"
+CommandStatusIdType CommandExecSPIFlashInfo(char* OutMessage);
+CommandStatusIdType CommandGetSPIFlashInfo(char* OutParam);
+
 #define COMMAND_LIST_END    ""
 
 /* Defines the end of command list. This is no actual command */


### PR DESCRIPTION
Add command to get SPI flash manufacturer and device id information: SPI_FLASH_INFOMY for human-readable format, and SPI_FLASH_INFOMY? for raw hex data.

Ref #42 