### PR TITLE
Makefile: comment unstable flash methods, fix dfu one. 

### DIFF
--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -1,7 +1,7 @@
 # This makefile uses sh in order to build the project.
-# Note when using AVR-Toolchain, you have to install cygwin and 
-# append cygwin's bin directory to the PATH environment variable 
-# because Atmel does not ship sh.exe anymore with the toolchain. 
+# Note when using AVR-Toolchain, you have to install cygwin and
+# append cygwin's bin directory to the PATH environment variable
+# because Atmel does not ship sh.exe anymore with the toolchain.
 SHELL = /bin/sh
 
 #Supported configurations
@@ -42,7 +42,7 @@ SETTINGS	+= -DDEFAULT_BUTTON_ACTION=BUTTON_ACTION_CYCLE_SETTINGS
 #Default long button action
 SETTINGS	+= -DDEFAULT_BUTTON_LONG_ACTION=BUTTON_ACTION_CYCLE_SETTINGS
 
-#Define if button action setting should be independent of active setting 
+#Define if button action setting should be independent of active setting
 #SETTINGS	+= -DBUTTON_SETTING_GLOBAL
 
 #Default LED functions
@@ -99,20 +99,21 @@ LUFA_PATH    = src/LUFA/LUFA
 CC_FLAGS     = -Werror -DUSE_LUFA_CONFIG_HEADER -DFLASH_DATA_ADDR=$(FLASH_DATA_ADDR) -DFLASH_DATA_SIZE=$(FLASH_DATA_SIZE) -DSPM_HELPER_ADDR=$(SPM_HELPER_ADDR) -DBUILD_DATE=$(BUILD_DATE) -DCOMMIT_ID=\"$(COMMIT_ID)\" $(SETTINGS)
 LD_FLAGS     = -Wl,--section-start=.flashdata=$(FLASH_DATA_ADDR) -Wl,--section-start=.spmhelper=$(SPM_HELPER_ADDR)
 OBJDIR       = Bin
-OBJECT_FILES = 
+OBJECT_FILES =
+CRYPTO_TOOL  = ../../Software/Tools/crypt_operations.py
 
 
 #AVRDUDE settings
-AVRDUDE_PROGRAMMER = flip2
-AVRDUDE_MCU = atxmega32a4
-AVRDUDE_PORT = usb
-AVRDUDE_WRITE_APP = -U application:w:$(TARGET).hex
-AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
-AVRDUDE_FLAGS = -p $(AVRDUDE_MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
+#AVRDUDE_PROGRAMMER = flip2
+#AVRDUDE_MCU = $(MCU)
+#AVRDUDE_PORT = usb
+#AVRDUDE_WRITE_APP = -U application:w:$(TARGET).hex
+#AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
+#AVRDUDE_FLAGS = -p $(AVRDUDE_MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
 
 #AVRDUDE settings to program the precompiled firmware
-AVRDUDE_WRITE_APP_LATEST = -U application:w:Latest/Chameleon-Mini.hex
-AVRDUDE_WRITE_EEPROM_LATEST = -U eeprom:w:Latest/Chameleon-Mini.eep
+#AVRDUDE_WRITE_APP_LATEST = -U application:w:Latest/Chameleon-Mini.hex
+#AVRDUDE_WRITE_EEPROM_LATEST = -U eeprom:w:Latest/Chameleon-Mini.eep
 
 
 # Default target
@@ -142,25 +143,27 @@ include $(LUFA_PATH)/Build/lufa_cppcheck.mk
 spmhelper: $(TARGET).elf
 	@echo $(MSG_OBJCPY_CMD) Extracting SPM helper HEX file from $(TARGET).elf
 	$(CROSS)-objcopy -O ihex -j .spmhelper $(SPM_HELPER_OBJCOPY) $(TARGET).elf $(TARGET).hex
-		
-# Program the device using avrdude  
-program: $(TARGET).hex $(TARGET).eep
-	avrdude $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_APP) $(AVRDUDE_WRITE_EEPROM)
+
+# Program the device using avrdude
+#program: $(TARGET).hex $(TARGET).eep
+#	avrdude $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_APP) $(AVRDUDE_WRITE_EEPROM)
 
 # Program the device using avrdude with the latest official firmware
-program-latest:
-	avrdude $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_APP_LATEST) $(AVRDUDE_WRITE_EEPROM_LATEST)
+#program-latest:
+#	avrdude $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_APP_LATEST) $(AVRDUDE_WRITE_EEPROM_LATEST)
 
 # Program the device using batchisp and the DFU bootloader
 # Note that the device has to be in bootloader mode already
-dfu-flip: $(TARGET).hex $(TARGET).eep
-	cp $(TARGET).eep EEPROM.hex
-	batchisp -hardware usb -device $(MCU) -operation erase f memory FLASH loadbuffer $(TARGET).hex program verify memory EEPROM loadbuffer EEPROM.hex program verify start reset 0
-	rm EEPROM.hex
+#dfu-flip: $(TARGET).hex $(TARGET).eep
+#	cp $(TARGET).eep EEPROM.hex
+#	batchisp -hardware usb -device $(MCU) -operation erase f memory FLASH loadbuffer $(TARGET).hex program verify memory EEPROM loadbuffer EEPROM.hex program verify start reset 0
+#	rm EEPROM.hex
 
 # Program the device using dfu-programmer
 dfu-prog: $(TARGET).hex $(TARGET).eep
-	dfu-programmer $(MCU) erase
-	dfu-programmer $(MCU) flash-eeprom $(TARGET).eep
-	dfu-programmer $(MCU) flash $(TARGET).hex
-	dfu-programmer $(MCU) reset
+	python3 $(CRYPTO_TOOL) scramblehex $(TARGET).eep $(TARGET).eep.scramble
+	python3 $(CRYPTO_TOOL) scramblehex $(TARGET).hex $(TARGET).hex.scramble
+	-dfu-programmer $(MCU) erase --force
+	dfu-programmer $(MCU) flash --eeprom --force --suppress-validation $(TARGET).eep.scramble
+	dfu-programmer $(MCU) flash --force --suppress-validation $(TARGET).hex.scramble
+	rm $(TARGET).eep.scramble $(TARGET).hex.scramble

--- a/Firmware/Chameleon-Mini/Makefile
+++ b/Firmware/Chameleon-Mini/Makefile
@@ -4,6 +4,15 @@
 # because Atmel does not ship sh.exe anymore with the toolchain.
 SHELL = /bin/sh
 
+# Switch to 'True' to tell if you work with an unlocked flashing setup (AVRISP mkII, or
+# original Atmel bootloader), or 'False' else (original RevE rebooted and USB flashing).
+# Original RevE rebooted needs specific scrambling to be flashed.
+# If you don't know, do not touch!
+UNLOCKED_F   = False
+# Python binary, needed to run scrambling operations to flash.
+# Change it according to your system.
+PYTHON_BIN   = /usr/bin/env python3
+
 #Supported configurations
 SETTINGS    += -DCONFIG_MF_CLASSIC_1K_SUPPORT
 #SETTINGS    += -DCONFIG_MF_CLASSIC_1K_7B_SUPPORT
@@ -102,19 +111,19 @@ OBJDIR       = Bin
 OBJECT_FILES =
 CRYPTO_TOOL  = ../../Software/Tools/crypt_operations.py
 
-
+ifeq ($(UNLOCKED_F),True)
 #AVRDUDE settings
-#AVRDUDE_PROGRAMMER = flip2
-#AVRDUDE_MCU = $(MCU)
-#AVRDUDE_PORT = usb
-#AVRDUDE_WRITE_APP = -U application:w:$(TARGET).hex
-#AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
-#AVRDUDE_FLAGS = -p $(AVRDUDE_MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
+AVRDUDE_PROGRAMMER = flip2
+AVRDUDE_MCU = $(MCU)
+AVRDUDE_PORT = usb
+AVRDUDE_WRITE_APP = -U application:w:$(TARGET).hex
+AVRDUDE_WRITE_EEPROM = -U eeprom:w:$(TARGET).eep
+AVRDUDE_FLAGS = -p $(AVRDUDE_MCU) -P $(AVRDUDE_PORT) -c $(AVRDUDE_PROGRAMMER)
 
 #AVRDUDE settings to program the precompiled firmware
-#AVRDUDE_WRITE_APP_LATEST = -U application:w:Latest/Chameleon-Mini.hex
-#AVRDUDE_WRITE_EEPROM_LATEST = -U eeprom:w:Latest/Chameleon-Mini.eep
-
+AVRDUDE_WRITE_APP_LATEST = -U application:w:Latest/Chameleon-Mini.hex
+AVRDUDE_WRITE_EEPROM_LATEST = -U eeprom:w:Latest/Chameleon-Mini.eep
+endif
 
 # Default target
 all:
@@ -144,26 +153,39 @@ spmhelper: $(TARGET).elf
 	@echo $(MSG_OBJCPY_CMD) Extracting SPM helper HEX file from $(TARGET).elf
 	$(CROSS)-objcopy -O ihex -j .spmhelper $(SPM_HELPER_OBJCOPY) $(TARGET).elf $(TARGET).hex
 
+ifeq ($(UNLOCKED_F),True)
 # Program the device using avrdude
-#program: $(TARGET).hex $(TARGET).eep
-#	avrdude $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_APP) $(AVRDUDE_WRITE_EEPROM)
+program: $(TARGET).hex $(TARGET).eep
+	avrdude $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_APP) $(AVRDUDE_WRITE_EEPROM)
 
 # Program the device using avrdude with the latest official firmware
-#program-latest:
-#	avrdude $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_APP_LATEST) $(AVRDUDE_WRITE_EEPROM_LATEST)
+program-latest:
+	avrdude $(AVRDUDE_FLAGS) $(AVRDUDE_WRITE_APP_LATEST) $(AVRDUDE_WRITE_EEPROM_LATEST)
 
 # Program the device using batchisp and the DFU bootloader
 # Note that the device has to be in bootloader mode already
-#dfu-flip: $(TARGET).hex $(TARGET).eep
-#	cp $(TARGET).eep EEPROM.hex
-#	batchisp -hardware usb -device $(MCU) -operation erase f memory FLASH loadbuffer $(TARGET).hex program verify memory EEPROM loadbuffer EEPROM.hex program verify start reset 0
-#	rm EEPROM.hex
+dfu-flip: $(TARGET).hex $(TARGET).eep
+	cp $(TARGET).eep EEPROM.hex
+	batchisp -hardware usb -device $(MCU) -operation erase f memory FLASH loadbuffer $(TARGET).hex program verify memory EEPROM loadbuffer EEPROM.hex program verify start reset 0
+	rm EEPROM.hex
 
-# Program the device using dfu-programmer
+# Program the device using dfu-programmer in unlocked flashing conditions
+# Note that the device has to be in bootloader mode already
+# dfu-programmer >= 0.7.2 required
 dfu-prog: $(TARGET).hex $(TARGET).eep
-	python3 $(CRYPTO_TOOL) scramblehex $(TARGET).eep $(TARGET).eep.scramble
-	python3 $(CRYPTO_TOOL) scramblehex $(TARGET).hex $(TARGET).hex.scramble
+	-dfu-programmer $(MCU) erase --force
+	dfu-programmer $(MCU) flash --eeprom --force --suppress-validation $(TARGET).eep
+	dfu-programmer $(MCU) flash --force --suppress-validation $(TARGET).hex
+
+else
+# Program the device using dfu-programmer for unlocked RevE rebooted USB DFU scenario
+# Note that the device has to be in bootloader mode already
+# dfu-programmer >= 0.7.2 required
+dfu-prog: $(TARGET).hex $(TARGET).eep
+	$(PYTHON_BIN) $(CRYPTO_TOOL) scramblehex $(TARGET).eep $(TARGET).eep.scramble
+	$(PYTHON_BIN) $(CRYPTO_TOOL) scramblehex $(TARGET).hex $(TARGET).hex.scramble
 	-dfu-programmer $(MCU) erase --force
 	dfu-programmer $(MCU) flash --eeprom --force --suppress-validation $(TARGET).eep.scramble
 	dfu-programmer $(MCU) flash --force --suppress-validation $(TARGET).hex.scramble
 	rm $(TARGET).eep.scramble $(TARGET).hex.scramble
+endif

--- a/README.md
+++ b/README.md
@@ -19,31 +19,31 @@ The chinese manufacturer had its firmware changes to themself which was limiting
 After talks with manufacturer, they also came to the conclusion that it should be open-sourced.  I managed to get source from them and agreed to make a public repository on GitHub.
 Since this firmware isn't in the official Chameleon mini repo,  I decided to make a 'iceman fork' of it.*
 
-## Notice      
+## Notice
 Let us make this fork awesome to play with. Do please play with it. Get excited and experiment with your enhanced Chameleon Mini device!
 
 ## First Steps
-This repo is focused on RevE Rebooted,    you can find useful information on [our wiki here](https://github.com/iceman1001/ChameleonMini-rebooted/wiki)
+This repo is focused on RevE Rebooted, you can find useful information on [our wiki here](https://github.com/iceman1001/ChameleonMini-rebooted/wiki)
 
 ### To upgrade the firmware of your ChameleonMini
 
-For RevG owners,  
+For RevG owners,
 please visit the [Getting Started page](https://rawgit.com/emsec/ChameleonMini/master/Doc/Doxygen/html/_page__getting_started.html) from the [doxygen documentation](https://rawgit.com/emsec/ChameleonMini/master/Doc/Doxygen/html/index.html).
 
-For RevE Rebooted owners,  
-please visit the [Flashing Windows](https://github.com/iceman1001/ChameleonMini-rebooted/wiki/Flashing---windows)
+For RevE Rebooted owners,
+please start with the [Windows walkthrough](https://github.com/iceman1001/ChameleonMini-rebooted/wiki/Getting-started)
 
 
 ## Supported Cards and Codecs
 See [here](https://github.com/emsec/ChameleonMini/wiki/Supported-Cards-and--Codecs).
 
 
-## GUI 
+## GUI
 Based on the partial source code release for the GUI we created a new GUI.
-[iceman Chameleon Mini GUI](https://github.com/iceman1001/ChameleonMini-rebootedGUI) 
+[iceman Chameleon Mini GUI](https://github.com/iceman1001/ChameleonMini-rebootedGUI)
 It is a windows .net based software and it is really nice to work with.
 Has support for Chameleon Mini revE / revG commands
-and dump management,  
+and dump management,
 and color templates for dumps,
 and multilanguage
 
@@ -52,10 +52,10 @@ Built by @bogition and @iceman1001
 ## Questions
 If you have any questions, please visit the issues page to the related hardware device you own and ask your questions there so everyone benefits from the answer.
 
-For RevG owners,  
-please visit the [REV_G Issues page](https://github.com/emsec/ChameleonMini/issues) 
+For RevG owners,
+please visit the [REV_G Issues page](https://github.com/emsec/ChameleonMini/issues)
 
-For RevE Rebooted owners,  
+For RevE Rebooted owners,
 please visit the [REV_E Rebooted Issues page](https://github.com/iceman1001/ChameleonMini-rebooted/issues)
 
 
@@ -74,7 +74,7 @@ The code repository contains
 
 ## Donate
 If you feel the love,  do feel free to become a iceman patron. For some tiers it comes with rewards
-https://www.patreon.com/iceman1001 
+https://www.patreon.com/iceman1001
 
 All support is welcome.
 


### PR DESCRIPTION
Following issues #11 and #93, and updating Linux/OSX flashing related wiki pages, I thought it would be good to integrate actual state of play in Makefile.

I commented out all flashing methods that suppose we have a hardware flashing setup, or that the bootloader in RevE is not scrambled, and I reworked `dfu-prog` target so it could actually work.

Also Linked getting started wiki page in README.md, by the way.