### PR TITLE
Fix #38 writable block0. Some Mifare refactor.

### DIFF
--- a/Firmware/Chameleon-Mini/Application/ISO14443-3A.c
+++ b/Firmware/Chameleon-Mini/Application/ISO14443-3A.c
@@ -94,4 +94,6 @@ bool ISO14443ACheckCRCA(const void* Buffer, uint16_t ByteCount)
 /* Coded in H to allow exportable inlining
 INLINE bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue);
 INLINE bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt);
+INLINE bool ISO14443AIsWakeUp(uint8_t* Buffer, bool FromHalt);
+INLINE void ISO14443ASetWakeUpResponse(uint8_t* Buffer, uint16_t ATQAValue);
 */

--- a/Firmware/Chameleon-Mini/Application/ISO14443-3A.c
+++ b/Firmware/Chameleon-Mini/Application/ISO14443-3A.c
@@ -7,8 +7,8 @@
 
 #include "ISO14443-3A.h"
 
-#define CRC_INIT		0x6363
-#define CRC_INIT_R		0xC6C6 /* Bit reversed */
+#define CRC_INIT        0x6363
+#define CRC_INIT_R      0xC6C6 /* Bit reversed */
 
 #define USE_HW_CRC
 
@@ -91,83 +91,7 @@ bool ISO14443ACheckCRCA(const void* Buffer, uint16_t ByteCount)
 }
 #endif
 
-#if 0
-bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue)
-{
-    uint8_t* DataPtr = (uint8_t*) Buffer;
-    uint8_t NVB = DataPtr[1];
-    //uint8_t CollisionByteCount = (NVB >> 4) & 0x0F;
-    //uint8_t CollisionBitCount =  (NVB >> 0) & 0x0F;
-
-    switch (NVB) {
-    case ISO14443A_NVB_AC_START:
-        /* Start of anticollision procedure.
-        * Send whole UID CLn + BCC */
-        DataPtr[0] = UidCL[0];
-        DataPtr[1] = UidCL[1];
-        DataPtr[2] = UidCL[2];
-        DataPtr[3] = UidCL[3];
-        DataPtr[4] = ISO14443A_CALC_BCC(DataPtr);
-
-        *BitCount = ISO14443A_CL_FRAME_SIZE;
-
-        return false;
-
-    case ISO14443A_NVB_AC_END:
-        /* End of anticollision procedure.
-        * Send SAK CLn if we are selected. */
-        if (    (DataPtr[2] == UidCL[0]) &&
-                (DataPtr[3] == UidCL[1]) &&
-                (DataPtr[4] == UidCL[2]) &&
-                (DataPtr[5] == UidCL[3]) ) {
-
-            DataPtr[0] = SAKValue;
-            ISO14443AAppendCRCA(Buffer, 1);
-
-            *BitCount = ISO14443A_SAK_FRAME_SIZE;
-            return true;
-        } else {
-            /* We have not been selected. Don't send anything. */
-            *BitCount = 0;
-            return false;
-        }
-    default:
-        uint8_t CollisionBitCount  = NVB & 0x0f;
-        if (CollisionBitCount == 0) {
-            /* Full-byte anticollision frame supports */
-            uint8_t CollisionByteCount = ((NVB >> 4) & 0x0f) - 2;
-            /* Check for our UID is selecting */
-            if (memcmp(UidCL, &DataPtr[2], CollisionByteCount) != 0) {
-                *BitCount = 0;
-                return false;
-            }
-            memcpy(DataPtr, &UidCL[CollisionByteCount], 4 - CollisionByteCount);
-            /* Calc original BCC */
-            DataPtr[4 - CollisionByteCount] = ISO14443A_CALC_BCC(UidCL);
-            *BitCount = (5 - CollisionByteCount) * BITS_PER_BYTE;
-        } else {
-            /* Partial-byte anticollision frame not supported */
-            *BitCount = 0;
-        }
-        return false;
-    }
-}
-
-bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt)
-{
-    uint8_t* DataPtr = (uint8_t*) Buffer;
-
-    if ( ((! FromHalt) && (DataPtr[0] == ISO14443A_CMD_REQA)) ||
-         (DataPtr[0] == ISO14443A_CMD_WUPA) ){
-        DataPtr[0] = (ATQAValue >> 0) & 0x00FF;
-        DataPtr[1] = (ATQAValue >> 8) & 0x00FF;
-
-        *BitCount = ISO14443A_ATQA_FRAME_SIZE;
-
-        return true;
-    } else {
-        return false;
-    }
-}
-
-#endif
+/* Coded in H to allow exportable inlining
+INLINE bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue);
+INLINE bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt);
+*/

--- a/Firmware/Chameleon-Mini/Application/ISO14443-3A.h
+++ b/Firmware/Chameleon-Mini/Application/ISO14443-3A.h
@@ -48,6 +48,7 @@
 void ISO14443AAppendCRCA(void* Buffer, uint16_t ByteCount);
 bool ISO14443ACheckCRCA(const void* Buffer, uint16_t ByteCount);
 
+/* Coded here to allow exportable inlining */
 INLINE bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue);
 INLINE bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt);
 

--- a/Firmware/Chameleon-Mini/Application/ISO14443-3A.h
+++ b/Firmware/Chameleon-Mini/Application/ISO14443-3A.h
@@ -51,6 +51,8 @@ bool ISO14443ACheckCRCA(const void* Buffer, uint16_t ByteCount);
 /* Coded here to allow exportable inlining */
 INLINE bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue);
 INLINE bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt);
+INLINE bool ISO14443AIsWakeUp(uint8_t* Buffer, bool FromHalt);
+INLINE void ISO14443ASetWakeUpResponse(uint8_t* Buffer, uint16_t ATQAValue);
 
 INLINE
 bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t SAKValue)
@@ -117,23 +119,30 @@ bool ISO14443ASelect(void* Buffer, uint16_t* BitCount, uint8_t* UidCL, uint8_t S
 }
 
 INLINE
+bool ISO14443AIsWakeUp(uint8_t* Buffer, bool FromHalt) {
+    return ( ((!FromHalt) && (Buffer[0] == ISO14443A_CMD_REQA))
+             || (Buffer[0] == ISO14443A_CMD_WUPA) );
+}
+
+INLINE
+void ISO14443ASetWakeUpResponse(uint8_t* Buffer, uint16_t ATQAValue) {
+    Buffer[0] = (ATQAValue >> 0) & 0x00FF;
+    Buffer[1] = (ATQAValue >> 8) & 0x00FF;
+}
+
+INLINE
 bool ISO14443AWakeUp(void* Buffer, uint16_t* BitCount, uint16_t ATQAValue, bool FromHalt)
 {
     uint8_t* DataPtr = (uint8_t*) Buffer;
-
-    if ( ((! FromHalt) && (DataPtr[0] == ISO14443A_CMD_REQA)) ||
-         (DataPtr[0] == ISO14443A_CMD_WUPA) ){
-        DataPtr[0] = (ATQAValue >> 0) & 0x00FF;
-        DataPtr[1] = (ATQAValue >> 8) & 0x00FF;
-
+    bool ret = false;
+    if ( ISO14443AIsWakeUp(DataPtr, FromHalt) ) {
+        ISO14443ASetWakeUpResponse(DataPtr, ATQAValue);
         *BitCount = ISO14443A_ATQA_FRAME_SIZE;
-
-        return true;
+        ret = true;
     } else {
         *BitCount = 0;
-
-        return false;
     }
+    return ret;
 }
 
 #endif

--- a/Firmware/Chameleon-Mini/Application/MifareClassic.c
+++ b/Firmware/Chameleon-Mini/Application/MifareClassic.c
@@ -40,11 +40,17 @@
 
 #define ACK_NAK_FRAME_SIZE          4         /* Bits */
 #define ACK_VALUE                   0x0A
-/* Here are values from NXP MF1S50YYX_V1 datasheet, 9.3 */
+/* NAK values from NXP MF1S50YYX_V1 datasheet, 9.3 */
 #define NAK_S50_BUFFEROK_OPKO       0x00
 #define NAK_S50_BUFFEROK_PARITYCRC  0x01
-#define NAK_S50_BUFFERKO_OPKO       0x02
-#define NAK_S50_BUFFERKO_PARITYCRC  0X03
+#define NAK_S50_BUFFERKO_OPKO       0x04
+#define NAK_S50_BUFFERKO_PARITYCRC  0x05
+/* NAK values in original RevG source code */
+#define NAK_INVALID_ARG             0x00
+#define NAK_CRC_ERROR               0x01
+#define NAK_NOT_AUTHED              0x04
+#define NAK_EEPROM_ERROR            0x05
+#define NAK_OTHER_ERROR             0x06
 
 #define CMD_AUTH_A                  0x60
 #define CMD_AUTH_B                  0x61

--- a/Firmware/Chameleon-Mini/Application/MifareClassic.c
+++ b/Firmware/Chameleon-Mini/Application/MifareClassic.c
@@ -11,39 +11,40 @@
 #include "../Codec/ISO14443-2A.h"
 #include "../Memory.h"
 #include "Crypto1.h"
-#include "../Random.h"
-#include "../LED.h"
 
 #define MFCLASSIC_1K_ATQA_VALUE     0x0004
 #define MFPlus_ATQA_VALUE           0x0044
 #define MFCLASSIC_4K_ATQA_VALUE     0x0002
 #define MFCLASSIC_1K_SAK_CL1_VALUE  0x08
 #define MFCLASSIC_4K_SAK_CL1_VALUE  0x18
-#define SAK_CL1_VALUE				ISO14443A_SAK_INCOMPLETE
-#define SAK_CL2_VALUE				ISO14443A_SAK_COMPLETE_NOT_COMPLIANT
+#define SAK_CL1_VALUE               ISO14443A_SAK_INCOMPLETE
+#define SAK_CL2_VALUE               ISO14443A_SAK_COMPLETE_NOT_COMPLIANT
 
+#define MEM_S0B0_ADDRESS            0x00
+#define MEM_INVALID_ADDRESS         0xFF
 #define MEM_UID_CL1_ADDRESS         0x00
 #define MEM_UID_CL1_SIZE            4
 #define MEM_UID_BCC1_ADDRESS        0x04
-#define MEM_UID_CL2_ADDRESS        	0x03
+#define MEM_UID_CL2_ADDRESS         0x03
 #define MEM_UID_CL2_SIZE            4
+#define MEM_UID7_SIZE               7         /* Bits */
 #define MEM_KEY_A_OFFSET            48        /* Bytes */
 #define MEM_KEY_B_OFFSET            58        /* Bytes */
-#define MEM_KEY_BIGSECTOR_OFFSET	192
+#define MEM_KEY_BIGSECTOR_OFFSET    192
 #define MEM_KEY_SIZE                6         /* Bytes */
 #define MEM_ACC_GPB_SIZE            4         /* Bytes */
 #define MEM_SECTOR_ADDR_MASK        0xFC
-#define MEM_BIGSECTOR_ADDR_MASK		0xF0
+#define MEM_BIGSECTOR_ADDR_MASK     0xF0
 #define MEM_BYTES_PER_BLOCK         16        /* Bytes */
 #define MEM_VALUE_SIZE              4         /* Bytes */
 
 #define ACK_NAK_FRAME_SIZE          4         /* Bits */
 #define ACK_VALUE                   0x0A
-#define NAK_INVALID_ARG             0x00
-#define NAK_CRC_ERROR               0x01
-#define NAK_NOT_AUTHED              0x04
-#define NAK_EEPROM_ERROR            0x05
-#define NAK_OTHER_ERROR             0x06
+/* Here are values from NXP MF1S50YYX_V1 datasheet, 9.3 */
+#define NAK_S50_BUFFEROK_OPKO       0x00
+#define NAK_S50_BUFFEROK_PARITYCRC  0x01
+#define NAK_S50_BUFFERKO_OPKO       0x02
+#define NAK_S50_BUFFERKO_PARITYCRC  0X03
 
 #define CMD_AUTH_A                  0x60
 #define CMD_AUTH_B                  0x61
@@ -66,6 +67,9 @@
 #define CMD_RESTORE_FRAME_SIZE      2        /* Bytes without CRCA */
 #define CMD_TRANSFER                0xB0
 #define CMD_TRANSFER_FRAME_SIZE     2        /* Bytes without CRCA */
+/* AUTH, HALT, READ, WRITE, INC/DECREMENT, TRANSFER and RESTORE all have same size */
+#define CMD_COMMON_FRAME_SIZE       2
+#define CMD_WUPA_BITCOUNT           7        /* Bits */
 
 /* Chinese magic backdoor commands (GEN 1A)*/
 #define CMD_CHINESE_UNLOCK          0x40
@@ -74,9 +78,11 @@
 
 /*
 Source: NXP: MF1S50YYX Product data sheet
-
+*/
+#define BYTE_SWAP(x)            (((uint8_t)(x)>>4)|((uint8_t)(x)<<4))
+#define ACC_NO_ACCESS           0x07
+/*
 Access conditions for the sector trailer
-
 Access bits     Access condition for                   Remark
             KEYA         Access bits  KEYB
 C1 C2 C3        read  write  read  write  read  write
@@ -98,24 +104,20 @@ C1 C2 C3        read  write  read  write  read  write
 #define ACC_TRAILOR_WRITE_ACC   0x08
 #define ACC_TRAILOR_READ_KEYB   0x10
 #define ACC_TRAILOR_WRITE_KEYB  0x20
-
-
-
 /*
 Access conditions for data blocks
-Access bits Access condition for 				Application
-C1 C2 C3 	read 	write 	increment 	decrement,
+Access bits Access condition for                Application
+C1 C2 C3    read    write   increment   decrement,
                                                 transfer,
                                                 restore
-
-0 0 0 		key A|B key A|B key A|B 	key A|B 	transport configuration
-0 1 0 		key A|B never 	never 		never 		read/write block
-1 0 0 		key A|B key B 	never 		never 		read/write block
-1 1 0 		key A|B key B 	key B 		key A|B 	value block
-0 0 1 		key A|B never 	never 		key A|B 	value block
-0 1 1 		key B 	key B 	never 		never 		read/write block
-1 0 1 		key B 	never 	never 		never 		read/write block
-1 1 1 		never 	never 	never 		never 		read/write block
+0 0 0       key A|B key A|B key A|B     key A|B     transport configuration
+0 1 0       key A|B never   never       never       read/write block
+1 0 0       key A|B key B   never       never       read/write block
+1 1 0       key A|B key B   key B       key A|B     value block
+0 0 1       key A|B never   never       key A|B     value block
+0 1 1       key B   key B   never       never       read/write block
+1 0 1       key B   never   never       never       read/write block
+1 1 1       never   never   never       never       read/write block
 
 */
 #define ACC_BLOCK_READ      0x01
@@ -251,13 +253,14 @@ static const uint8_t abTrailorAccessConditions[8][2] =
 };
 */
 
-static enum {
+enum estate {
+    STATE_INVALID,
     STATE_HALT,
     STATE_IDLE,
     STATE_CHINESE_IDLE,
     STATE_CHINESE_WRITE,
     STATE_READY1,
-	STATE_READY2,
+    STATE_READY2,
     STATE_ACTIVE,
     STATE_AUTHING,
     STATE_AUTHED_IDLE,
@@ -265,24 +268,24 @@ static enum {
     STATE_INCREMENT,
     STATE_DECREMENT,
     STATE_RESTORE
-} State;
+};
+/* Init to get sure we have a controlled value wherever we start */
+static enum estate State = STATE_INVALID;
 
 static uint8_t CardResponse[4];
 static uint8_t ReaderResponse[4];
 static uint8_t CurrentAddress;
 static uint8_t BlockBuffer[MEM_BYTES_PER_BLOCK];
-static uint8_t AccessConditions[MEM_ACC_GPB_SIZE]; /* Access Conditions + General purpose Byte */
+/* Access conditions not implemented yet
+static uint8_t AccessConditions[MEM_ACC_GPB_SIZE];
 static uint8_t AccessAddress;
+*/
 static uint16_t CardATQAValue;
 static uint8_t CardSAKValue;
+static bool is7BitsUID = false;
 
-static uint8_t _7BUID = 0x00;
-static bool FromHalt = false;
-
-#define BYTE_SWAP(x) (((uint8_t)(x)>>4)|((uint8_t)(x)<<4))
-#define NO_ACCESS 0x07
-
-/* decode Access conditions for a block */
+/*
+// Decode Access conditions for a block
 INLINE uint8_t GetAccessCondition(uint8_t Block)
 {
     uint8_t  InvSAcc0;
@@ -295,14 +298,14 @@ INLINE uint8_t GetAccessCondition(uint8_t Block)
     InvSAcc0 = ~BYTE_SWAP(Acc0);
     InvSAcc1 = ~BYTE_SWAP(Acc1);
 
-    /* Check */
-    if ( ((InvSAcc0 ^ Acc1) & 0xf0) ||   /* C1x */
-         ((InvSAcc0 ^ Acc2) & 0x0f) ||   /* C2x */
-         ((InvSAcc1 ^ Acc2) & 0xf0))     /* C3x */
+    // Check
+    if ( ((InvSAcc0 ^ Acc1) & 0xf0) ||   // C1x
+         ((InvSAcc0 ^ Acc2) & 0x0f) ||   // C2x
+         ((InvSAcc1 ^ Acc2) & 0xf0))     // C3x
     {
-      return(NO_ACCESS);
+      return(ACC_NO_ACCESS);
     }
-    /* Fix for MFClassic 4K cards */
+    // Fix for MFClassic 4K cards
     if(Block<128)
         Block &= 3;
     else {
@@ -317,9 +320,9 @@ INLINE uint8_t GetAccessCondition(uint8_t Block)
             Block=2;
     }
 
-    Acc0 = ~Acc0;       /* C1x Bits to bit 0..3 */
-    Acc1 =  Acc2;       /* C2x Bits to bit 0..3 */
-    Acc2 =  Acc2 >> 4;  /* C3x Bits to bit 0..3 */
+    Acc0 = ~Acc0;       // C1x Bits to bit 0..3
+    Acc1 =  Acc2;       // C2x Bits to bit 0..3
+    Acc2 =  Acc2 >> 4;  // C3x Bits to bit 0..3
 
     if(Block)
     {
@@ -327,12 +330,13 @@ INLINE uint8_t GetAccessCondition(uint8_t Block)
         Acc1 >>= Block;
         Acc2 >>= Block;
     }
-    /* combine the bits */
+    // combine the bits
     ResultForBlock = ((Acc2 & 1) << 2) |
                      ((Acc1 & 1) << 1) |
                      (Acc0 & 1);
     return(ResultForBlock);
 }
+*/
 
 INLINE bool CheckValueIntegrity(uint8_t* Block)
 {
@@ -381,16 +385,16 @@ void MifareClassicAppInit1K(void)
     State = STATE_IDLE;
     CardATQAValue = MFCLASSIC_1K_ATQA_VALUE;
     CardSAKValue = MFCLASSIC_1K_SAK_CL1_VALUE;
-	_7BUID = 0x00;
+    is7BitsUID = false;
 }
 
 void MifarePlus1kAppInit_7B(void)
 {
-	State = STATE_IDLE;
-	CardATQAValue = MFPlus_ATQA_VALUE;
-	CardSAKValue = MFCLASSIC_1K_SAK_CL1_VALUE;
-	uint8_t UidSize = ActiveConfiguration.UidSize;
-	_7BUID = (UidSize == 7);
+    State = STATE_IDLE;
+    CardATQAValue = MFPlus_ATQA_VALUE;
+    CardSAKValue = MFCLASSIC_1K_SAK_CL1_VALUE;
+    uint8_t UidSize = ActiveConfiguration.UidSize;
+    is7BitsUID = (UidSize == MEM_UID7_SIZE);
 }
 
 void MifareClassicAppInit4K(void)
@@ -398,7 +402,7 @@ void MifareClassicAppInit4K(void)
     State = STATE_IDLE;
     CardATQAValue = MFCLASSIC_4K_ATQA_VALUE;
     CardSAKValue = MFCLASSIC_4K_SAK_CL1_VALUE;
-	_7BUID = 0x00;
+    is7BitsUID = false;
 }
 
 void MifareClassicAppReset(void)
@@ -412,540 +416,460 @@ void MifareClassicAppTask(void)
 }
 
 
+/* Handle a CMD_HALT during main process, as can be raised in many states.
+* Sets State, response buffer and returns response size */
+INLINE uint16_t mfcHandleHaltCommand(uint8_t* Buffer) {
+    uint16_t ret = ACK_NAK_FRAME_SIZE;
+    /* Halts the tag. According to the ISO14443, the second byte is supposed to be 0 */
+    if (Buffer[1] == 0) {
+        if (ISO14443ACheckCRCA(Buffer, CMD_HALT_FRAME_SIZE)) {
+            /* According to ISO14443, we must not send anything to ACK */
+            State = STATE_HALT;
+            ret = ISO14443A_APP_NO_RESPONSE;
+        } else {
+            Buffer[0] = NAK_S50_BUFFERKO_PARITYCRC;
+        }
+    } else {
+        Buffer[0] = NAK_S50_BUFFERKO_OPKO;
+    }
+    return ret;
+}
+
 uint16_t MifareClassicAppProcess(uint8_t* Buffer, uint16_t BitCount)
 {
-    /* Wakeup and Request may occure in all states */
-    if ( (BitCount == 7) &&
-         /* precheck of WUP/REQ because ISO14443AWakeUp destroys BitCount */
-         (((State != STATE_HALT) && (Buffer[0] == ISO14443A_CMD_REQA)) ||
-         (Buffer[0] == ISO14443A_CMD_WUPA) )){
+    /* What will we respond at the end of this buffer handling. Default to nothing. */
+    uint16_t ret = ISO14443A_APP_NO_RESPONSE;
 
-        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue, FromHalt)) {
-            AccessAddress = 0xff;
-            State = STATE_READY1;
-            return BitCount;
-        }
-    }
+    /* Do we come from HALT state ? */
+    bool isFromHaltState = (State == STATE_HALT);
 
-    switch(State) {
-    case STATE_IDLE:
-    case STATE_HALT:
-
-        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue, true)) {
-            State = STATE_READY1;
-            return BitCount;
-        }
+    /* Wakeup and Request may occure in all states. The ISO14443 function alters Buffer
+    * if correct case, but alters BitCount in any case, hence the dummy copy we pass. */
+    uint16_t dummyBitCount = BitCount;
+    if ( (BitCount == CMD_WUPA_BITCOUNT)
+         && ISO14443AWakeUp(Buffer, &dummyBitCount, CardATQAValue, isFromHaltState) ) {
+            /* Not implemented yet. AccessAddress = MEM_INVALID_ADDRESS; */
+            State = isFromHaltState ? STATE_HALT : STATE_IDLE;
+            ret = ISO14443A_ATQA_FRAME_SIZE;
+    } else {
+        switch(State) {
+        case STATE_IDLE:
+        case STATE_HALT:
 #ifdef SUPPORT_MF_CLASSIC_MAGIC_MODE
-        else if (Buffer[0] == CMD_CHINESE_UNLOCK) {
-            State = STATE_CHINESE_IDLE;
-            Buffer[0] = ACK_VALUE;
-            return ACK_NAK_FRAME_SIZE;
-        }
-#endif
-        break;
-
-#ifdef SUPPORT_MF_CLASSIC_MAGIC_MODE
-    case STATE_CHINESE_IDLE:
-        /* Support special china commands that dont require authentication. */
-        if (Buffer[0] == CMD_CHINESE_UNLOCK_RW) {
-            /* Unlock read and write commands */
-            Buffer[0] = ACK_VALUE;
-            return ACK_NAK_FRAME_SIZE;
-        } else if (Buffer[0] == CMD_CHINESE_WIPE) {
-            /* Wipe memory */
-            Buffer[0] = ACK_VALUE;
-            return ACK_NAK_FRAME_SIZE;
-        } else if (Buffer[0] == CMD_READ) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_READ_FRAME_SIZE)) {
-                /* Read command. Read data from memory and append CRCA. */
-                MemoryReadBlock(Buffer, (uint16_t) Buffer[1] * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
-                ISO14443AAppendCRCA(Buffer, MEM_BYTES_PER_BLOCK);
-
-                return (CMD_READ_RESPONSE_FRAME_SIZE + ISO14443A_CRCA_SIZE )
-                        * BITS_PER_BYTE;
-            } else {
-                Buffer[0] = NAK_CRC_ERROR;
-                return ACK_NAK_FRAME_SIZE;
-            }
-        } else if (Buffer[0] == CMD_WRITE) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_WRITE_FRAME_SIZE)) {
-                /* Write command. Store the address and prepare for the upcoming data.
-                * Respond with ACK. */
-                CurrentAddress = Buffer[1];
-                State = STATE_CHINESE_WRITE;
-
+            if (Buffer[0] == CMD_CHINESE_UNLOCK) {
+                State = STATE_CHINESE_IDLE;
                 Buffer[0] = ACK_VALUE;
-                return ACK_NAK_FRAME_SIZE;
-            } else {
-                Buffer[0] = NAK_CRC_ERROR;
-                return ACK_NAK_FRAME_SIZE;
+                ret = ACK_NAK_FRAME_SIZE;
             }
-        } else if (Buffer[0] == CMD_HALT) {
-            /* Halts the tag. According to the ISO14443, the second
-            * byte is supposed to be 0. */
-            if (Buffer[1] == 0) {
-                if (ISO14443ACheckCRCA(Buffer, CMD_HALT_FRAME_SIZE)) {
-                    /* According to ISO14443, we must not send anything
-                    * in order to acknowledge the HALT command. */
-                    State = STATE_HALT;
-                    return ISO14443A_APP_NO_RESPONSE;
+#endif
+            break;
+
+#ifdef SUPPORT_MF_CLASSIC_MAGIC_MODE
+        case STATE_CHINESE_IDLE:
+            /* Support special china commands that dont require authentication. */
+            if (Buffer[0] == CMD_CHINESE_UNLOCK_RW) {
+                /* Unlock read and write commands */
+                Buffer[0] = ACK_VALUE;
+                ret = ACK_NAK_FRAME_SIZE;
+            } else if (Buffer[0] == CMD_CHINESE_WIPE) {
+                /* Wipe memory */
+                Buffer[0] = ACK_VALUE;
+                ret = ACK_NAK_FRAME_SIZE;
+            } else if (Buffer[0] == CMD_READ) {
+                if (ISO14443ACheckCRCA(Buffer, CMD_READ_FRAME_SIZE)) {
+                    /* Read command. Read data from memory and append CRCA. */
+                    MemoryReadBlock(Buffer, (uint16_t) Buffer[1] * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
+                    ISO14443AAppendCRCA(Buffer, MEM_BYTES_PER_BLOCK);
+                    ret = (CMD_READ_RESPONSE_FRAME_SIZE + ISO14443A_CRCA_SIZE) * BITS_PER_BYTE;
                 } else {
-                    Buffer[0] = NAK_CRC_ERROR;
-                    return ACK_NAK_FRAME_SIZE;
+                    Buffer[0] = NAK_S50_BUFFERKO_PARITYCRC;
+                    ret = ACK_NAK_FRAME_SIZE;
                 }
+            } else if (Buffer[0] == CMD_WRITE) {
+                if (ISO14443ACheckCRCA(Buffer, CMD_WRITE_FRAME_SIZE)) {
+                    /* Write command. Store the address and prepare for the upcoming data.
+                    * Respond with ACK. */
+                    CurrentAddress = Buffer[1];
+                    State = STATE_CHINESE_WRITE;
+                    Buffer[0] = ACK_VALUE;
+                    ret = ACK_NAK_FRAME_SIZE;
+                } else {
+                    Buffer[0] = NAK_S50_BUFFERKO_PARITYCRC;
+                    ret = ACK_NAK_FRAME_SIZE;
+                }
+            } else if (Buffer[0] == CMD_HALT) {
+                ret = mfcHandleHaltCommand(Buffer);
+            }
+            break;
+
+        case STATE_CHINESE_WRITE:
+            if (ISO14443ACheckCRCA(Buffer, MEM_BYTES_PER_BLOCK)) {
+                /* CRC check passed. Write data into memory and send ACK. */
+                if (!ActiveConfiguration.ReadOnly) {
+                    MemoryWriteBlock(Buffer, CurrentAddress * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
+                }
+                Buffer[0] = ACK_VALUE;
             } else {
-                Buffer[0] = NAK_INVALID_ARG;
-                return ACK_NAK_FRAME_SIZE;
+                /* CRC Error. */
+                Buffer[0] = NAK_S50_BUFFERKO_PARITYCRC;
             }
-        }
-        break;
-
-    case STATE_CHINESE_WRITE:
-        if (ISO14443ACheckCRCA(Buffer, MEM_BYTES_PER_BLOCK)) {
-            /* CRC check passed. Write data into memory and send ACK. */
-            if (!ActiveConfiguration.ReadOnly) {
-                MemoryWriteBlock(Buffer, CurrentAddress * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
-            }
-
-            Buffer[0] = ACK_VALUE;
-        } else {
-            /* CRC Error. */
-            Buffer[0] = NAK_CRC_ERROR;
-        }
-
-        State = STATE_CHINESE_IDLE;
-
-        return ACK_NAK_FRAME_SIZE;
+            State = STATE_CHINESE_IDLE;
+            ret = ACK_NAK_FRAME_SIZE;
+            break;
 #endif
 
-    case STATE_READY1:
-        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue, false)) {
-            State = STATE_READY1;
-            return BitCount;
-        } else if (Buffer[0] == ISO14443A_CMD_SELECT_CL1) {
-            /* Load UID CL1 and perform anticollision */
-            uint8_t UidCL1[ISO14443A_CL_UID_SIZE];
-
-            if (_7BUID) {
-	            MemoryReadBlock(&UidCL1[1], MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE-1);
-	            UidCL1[0] = ISO14443A_UID0_CT;
-
-	            if (ISO14443ASelect(Buffer, &BitCount, UidCL1, SAK_CL1_VALUE))
-				    State = STATE_READY2;
-
-	        } else {
-                MemoryReadBlock(UidCL1, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
-                if (ISO14443ASelect(Buffer, &BitCount, UidCL1, CardSAKValue)) {
-                    AccessAddress = 0xff; /* invalid, force reload */
-                    State = STATE_ACTIVE;
-                }
-            }
-            return BitCount;
-        } else {
-            /* Unknown command. Enter HALT state. */
-            State = STATE_HALT;
-        }
-        break;
-
-    case STATE_READY2:
-        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue, false)) {
-	       State = STATE_READY1;
-	       return BitCount;
-	    } else if (Buffer[0] == ISO14443A_CMD_SELECT_CL2) {
-
-	       /* Load UID CL2 and perform anticollision */
-	       uint8_t UidCL2[ISO14443A_CL_UID_SIZE];
-	       MemoryReadBlock(UidCL2, MEM_UID_CL2_ADDRESS, MEM_UID_CL2_SIZE);
-
-	       if (ISO14443ASelect(Buffer, &BitCount, UidCL2, CardSAKValue)) {
-               AccessAddress = 0xff; /* invalid, force reload */
-		       State = STATE_ACTIVE;
-	       }
-		   return BitCount;
-	    } else {
-          /* Unknown command. Enter HALT state. */
-          State = STATE_HALT;
-        }
-    break;
-
-    case STATE_ACTIVE:
-        if (ISO14443AWakeUp(Buffer, &BitCount, CardATQAValue, false)) {
-            State = STATE_READY1;
-            return BitCount;
-        } else if (Buffer[0] == CMD_HALT) {
-
-            /* Halts the tag. According to the ISO14443, the second
-            * byte is supposed to be 0. */
-            if (Buffer[1] == 0) {
-                if (ISO14443ACheckCRCA(Buffer, CMD_HALT_FRAME_SIZE)) {
-                    /* According to ISO14443, we must not send anything
-                    * in order to acknowledge the HALT command. */
-                    State = STATE_HALT;
-                    return ISO14443A_APP_NO_RESPONSE;
+        case STATE_READY1:
+            if (Buffer[0] == ISO14443A_CMD_SELECT_CL1) {
+                /* Load UID CL1 and perform anticollision */
+                uint8_t UidCL1[ISO14443A_CL_UID_SIZE];
+                if (is7BitsUID) {
+                    MemoryReadBlock(&UidCL1[1], MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE-1);
+                    UidCL1[0] = ISO14443A_UID0_CT;
+                    if (ISO14443ASelect(Buffer, &BitCount, UidCL1, SAK_CL1_VALUE)) {
+                        State = STATE_READY2;
+                    }
                 } else {
-                    Buffer[0] = NAK_CRC_ERROR;
-                    return ACK_NAK_FRAME_SIZE;
+                    MemoryReadBlock(UidCL1, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
+                    if (ISO14443ASelect(Buffer, &BitCount, UidCL1, CardSAKValue)) {
+                        /* Not implemented yet. AccessAddress = MEM_INVALID_ADDRESS; */
+                        State = STATE_ACTIVE;
+                    }
                 }
+                ret = BitCount;
             } else {
-                Buffer[0] = NAK_INVALID_ARG;
-                return ACK_NAK_FRAME_SIZE;
+                /* Unknown command. Enter HALT state. */
+                State = STATE_HALT;
+                ret = ISO14443A_APP_NO_RESPONSE;
             }
-        } else if ( (Buffer[0] == CMD_AUTH_A) || (Buffer[0] == CMD_AUTH_B)) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_AUTH_FRAME_SIZE)) {
-                uint8_t SectorAddress;
-                uint8_t KeyOffset = (Buffer[0] == CMD_AUTH_A ? MEM_KEY_A_OFFSET : MEM_KEY_B_OFFSET);
-                /* Fix for MFClassic 4k cards */
-                if(Buffer[1] >= 128) {
-                    SectorAddress = Buffer[1] & MEM_BIGSECTOR_ADDR_MASK;
-                    KeyOffset += MEM_KEY_BIGSECTOR_OFFSET;
+            break;
+
+        case STATE_READY2:
+            if (Buffer[0] == ISO14443A_CMD_SELECT_CL2) {
+               /* Load UID CL2 and perform anticollision */
+               uint8_t UidCL2[ISO14443A_CL_UID_SIZE];
+               MemoryReadBlock(UidCL2, MEM_UID_CL2_ADDRESS, MEM_UID_CL2_SIZE);
+               if (ISO14443ASelect(Buffer, &BitCount, UidCL2, CardSAKValue)) {
+                   State = STATE_ACTIVE;
+               }
+               ret = BitCount;
+            } else {
+              /* Unknown command. Enter HALT state. */
+              State = STATE_HALT;
+              ret = ISO14443A_APP_NO_RESPONSE;
+            }
+            break;
+
+        case STATE_ACTIVE:
+            if (Buffer[0] == CMD_HALT) {
+                ret = mfcHandleHaltCommand(Buffer);
+            } else if ((Buffer[0] == CMD_AUTH_A) || (Buffer[0] == CMD_AUTH_B)) {
+                if (ISO14443ACheckCRCA(Buffer, CMD_AUTH_FRAME_SIZE)) {
+                    uint8_t SectorAddress;
+                    uint8_t KeyOffset = (Buffer[0] == CMD_AUTH_A ? MEM_KEY_A_OFFSET : MEM_KEY_B_OFFSET);
+                    /* Fix for MFClassic 4k cards */
+                    if(Buffer[1] >= 128) {
+                        SectorAddress = Buffer[1] & MEM_BIGSECTOR_ADDR_MASK;
+                        KeyOffset += MEM_KEY_BIGSECTOR_OFFSET;
+                    } else {
+                        SectorAddress = Buffer[1] & MEM_SECTOR_ADDR_MASK;
+                    }
+                    uint16_t KeyAddress = (uint16_t) SectorAddress * MEM_BYTES_PER_BLOCK + KeyOffset;
+                    uint8_t Key[6];
+                    uint8_t Uid[4];
+                    uint8_t CardNonce[4] = {0x01,0x20,0x01,0x45};
+                    uint8_t CardNonceSuccessor1[4] = {0x63, 0xe5, 0xbc, 0xa7};
+                    uint8_t CardNonceSuccessor2[4] = {0x99, 0x37, 0x30, 0xbd};
+                    /* Read UID and key from memory */
+                    if (is7BitsUID) {
+                        MemoryReadBlock(Uid, MEM_UID_CL2_ADDRESS, MEM_UID_CL2_SIZE);
+                    } else {
+                        MemoryReadBlock(Uid, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
+                    }
+                    MemoryReadBlock(Key, KeyAddress, MEM_KEY_SIZE);
+                    /* Precalculate the reader response from card-nonce */
+                    memcpy(ReaderResponse, CardNonceSuccessor1, 4);
+                    /* Precalculate our response from the reader response */
+                    memcpy(CardResponse, CardNonceSuccessor2, 4);
+                    for (uint8_t i=0; i<sizeof(CardNonce); i++) {
+                        Buffer[i] = CardNonce[i];
+                    }
+                    /* Setup crypto1 cipher. Discard in-place encrypted CardNonce. */
+                    Crypto1Setup(Key, Uid, CardNonce, NULL);
+                    /* Respond with the random card nonce and expect further authentication
+                    * form the reader in the next frame. */
+                    State = STATE_AUTHING;
+                    ret = CMD_AUTH_RB_FRAME_SIZE * BITS_PER_BYTE;
                 } else {
-                    SectorAddress = Buffer[1] & MEM_SECTOR_ADDR_MASK;
+                    Buffer[0] = NAK_S50_BUFFERKO_PARITYCRC;
+                    ret = ACK_NAK_FRAME_SIZE;
                 }
-                uint16_t KeyAddress = (uint16_t) SectorAddress * MEM_BYTES_PER_BLOCK + KeyOffset;
-                uint8_t Key[6];
-                uint8_t Uid[4];
-			    uint8_t CardNonce[4] = {0x01,0x20,0x01,0x45};
-                uint8_t CardNonceSuccessor1[4] = {0x63, 0xe5, 0xbc, 0xa7};
-                uint8_t CardNonceSuccessor2[4] = {0x99, 0x37, 0x30, 0xbd};
-
-                /* Generate a random nonce and read UID and key from memory */
-                //RandomGetBuffer(CardNonce, sizeof(CardNonce));
-                if (_7BUID)
-					MemoryReadBlock(Uid, MEM_UID_CL2_ADDRESS, MEM_UID_CL2_SIZE);
-                else
-                    MemoryReadBlock(Uid, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
-
-                MemoryReadBlock(Key, KeyAddress, MEM_KEY_SIZE);
-
-                /* Precalculate the reader response from card-nonce */
-                memcpy(ReaderResponse, CardNonceSuccessor1, 4);
-
-                /* Precalculate our response from the reader response */
-                memcpy(CardResponse, CardNonceSuccessor2, 4);
-
-                /* Respond with the random card nonce and expect further authentication
-                * form the reader in the next frame. */
-                State = STATE_AUTHING;
-
-                for (uint8_t i=0; i<sizeof(CardNonce); i++)
-                    Buffer[i] = CardNonce[i];
-
-                /* Setup crypto1 cipher. Discard in-place encrypted CardNonce. */
-                Crypto1Setup(Key, Uid, CardNonce, NULL);
-
-                return CMD_AUTH_RB_FRAME_SIZE * BITS_PER_BYTE;
+            /* TODO: ? RevG has a "READ_SIG" command for EV1, which is a "CMD_RESTORE"
+            * without operand and with a special fixed key.
+            * See MifareClassic.c line 677 as of commit 94d24d9 */
+            } else if ( (Buffer[0] == CMD_READ) || (Buffer[0] == CMD_WRITE)
+                        || (Buffer[0] == CMD_DECREMENT) || (Buffer[0] == CMD_INCREMENT)
+                        || (Buffer[0] == CMD_RESTORE) || (Buffer[0] == CMD_TRANSFER) ) {
+                State = STATE_IDLE;
+                Buffer[0] = NAK_S50_BUFFEROK_OPKO;
+                ret = ACK_NAK_FRAME_SIZE;
             } else {
-                Buffer[0] = NAK_CRC_ERROR;
-                return ACK_NAK_FRAME_SIZE;
+                /* Unknown command. Enter HALT state. */
+                State = STATE_HALT;
+                ret = ISO14443A_APP_NO_RESPONSE;
             }
-        } else if ( (Buffer[0] == CMD_READ) ||
-		            (Buffer[0] == CMD_WRITE) ||
-					(Buffer[0] == CMD_DECREMENT) ||
-					(Buffer[0] == CMD_INCREMENT) ||
-					(Buffer[0] == CMD_RESTORE) ||
-					(Buffer[0] == CMD_TRANSFER) ) {
-            State = STATE_IDLE;
-            Buffer[0] = NAK_NOT_AUTHED;
-            return ACK_NAK_FRAME_SIZE;
-        } else {
-            /* Unknown command. Enter HALT state. */
-            State = STATE_IDLE;
-            return ISO14443A_APP_NO_RESPONSE;
-        }
-        break;
+            break;
 
-    case STATE_AUTHING:
-        /* Reader delivers an encrypted nonce. We use it
-        * to setup the crypto1 LFSR in nonlinear feedback mode.
-        * Furthermore it delivers an encrypted answer. Decrypt and check it */
-        Crypto1Auth(&Buffer[0]);
-
-        for (uint8_t i=0; i<4; i++)
-            Buffer[i+4] ^= Crypto1Byte();
-
-        if ((Buffer[4] == ReaderResponse[0]) &&
-            (Buffer[5] == ReaderResponse[1]) &&
-            (Buffer[6] == ReaderResponse[2]) &&
-            (Buffer[7] == ReaderResponse[3])) {
-            /* Reader is authenticated. Encrypt the precalculated card response
-            * and generate the parity bits. */
-            for (uint8_t i=0; i<sizeof(CardResponse); i++) {
-                Buffer[i] = CardResponse[i] ^ Crypto1Byte();
-                Buffer[ISO14443A_BUFFER_PARITY_OFFSET + i] = ODD_PARITY(CardResponse[i]) ^ Crypto1FilterOutput();
+        case STATE_AUTHING:
+            /* Reader delivers an encrypted nonce. We use it
+            * to setup the crypto1 LFSR in nonlinear feedback mode.
+            * Furthermore it delivers an encrypted answer. Decrypt and check it */
+            Crypto1Auth(&Buffer[0]);
+            for (uint8_t i=0; i<4; i++) {
+                Buffer[i+4] ^= Crypto1Byte();
             }
-
-            State = STATE_AUTHED_IDLE;
-
-            return (CMD_AUTH_BA_FRAME_SIZE * BITS_PER_BYTE) | ISO14443A_APP_CUSTOM_PARITY;
-        } else {
-            /* Just reset on authentication error. */
-            State = STATE_IDLE;
-        }
-
-        break;
-
-    case STATE_AUTHED_IDLE:
-        /* In this state, all communication is encrypted. Thus we first have to encrypt
-        * the incoming data. */
-        for (uint8_t i=0; i<4; i++)
-            Buffer[i] ^= Crypto1Byte();
-
-        if (Buffer[0] == CMD_READ) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_READ_FRAME_SIZE)) {
-                /* Read command. Read data from memory and append CRCA. */
-                MemoryReadBlock(Buffer, (uint16_t) Buffer[1] * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
-                ISO14443AAppendCRCA(Buffer, MEM_BYTES_PER_BLOCK);
-
-                /* Encrypt and calculate parity bits. */
-                for (uint8_t i=0; i<(ISO14443A_CRCA_SIZE + MEM_BYTES_PER_BLOCK); i++) {
-                    uint8_t Plain = Buffer[i];
-                    Buffer[i] = Plain ^ Crypto1Byte();
-                    Buffer[ISO14443A_BUFFER_PARITY_OFFSET + i] = ODD_PARITY(Plain) ^ Crypto1FilterOutput();
+            if ( (Buffer[4] == ReaderResponse[0]) && (Buffer[5] == ReaderResponse[1])
+                && (Buffer[6] == ReaderResponse[2]) && (Buffer[7] == ReaderResponse[3]) ) {
+                /* Reader is authenticated. Encrypt the precalculated card response
+                * and generate the parity bits. */
+                for (uint8_t i=0; i<sizeof(CardResponse); i++) {
+                    Buffer[i] = CardResponse[i] ^ Crypto1Byte();
+                    Buffer[ISO14443A_BUFFER_PARITY_OFFSET + i] = ODD_PARITY(CardResponse[i]) ^ Crypto1FilterOutput();
                 }
-
-                return ( (CMD_READ_RESPONSE_FRAME_SIZE + ISO14443A_CRCA_SIZE ) * BITS_PER_BYTE) | ISO14443A_APP_CUSTOM_PARITY;
-            } else {
-                Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-                return ACK_NAK_FRAME_SIZE;
-            }
-        } else if (Buffer[0] == CMD_WRITE) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_WRITE_FRAME_SIZE)) {
-                /* Write command. Store the address and prepare for the upcoming data.
-                * Respond with ACK. */
-                CurrentAddress = Buffer[1];
-                State = STATE_WRITE;
-                Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
-            } else {
-                Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-            }
-            return ACK_NAK_FRAME_SIZE;
-        } else if (Buffer[0] == CMD_DECREMENT) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_DECREMENT_FRAME_SIZE)) {
-                CurrentAddress = Buffer[1];
-                State = STATE_DECREMENT;
-                Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
-            } else {
-                Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-            }
-            return ACK_NAK_FRAME_SIZE;
-        } else if (Buffer[0] == CMD_INCREMENT) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_DECREMENT_FRAME_SIZE)) {
-                CurrentAddress = Buffer[1];
-                State = STATE_INCREMENT;
-                Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
-            } else {
-                Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-            }
-            return ACK_NAK_FRAME_SIZE;
-        } else if (Buffer[0] == CMD_RESTORE) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_DECREMENT_FRAME_SIZE)) {
-                CurrentAddress = Buffer[1];
-                State = STATE_RESTORE;
-                Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
-            } else {
-                Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-            }
-            return ACK_NAK_FRAME_SIZE;
-        }else if (Buffer[0] == CMD_TRANSFER) {
-            /* Write back the global block buffer to the desired block address */
-            if (ISO14443ACheckCRCA(Buffer, CMD_TRANSFER_FRAME_SIZE)) {
-                if (!ActiveConfiguration.ReadOnly) {
-                    MemoryWriteBlock(BlockBuffer, (uint16_t) Buffer[1] * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK );
-                } else {
-                    /* In read only mode, silently ignore the write */
-                }
-
-                Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
-            } else {
-                Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-            }
-
-            return ACK_NAK_FRAME_SIZE;
-        } else if ( (Buffer[0] == CMD_AUTH_A) || (Buffer[0] == CMD_AUTH_B) ) {
-            if (ISO14443ACheckCRCA(Buffer, CMD_AUTH_FRAME_SIZE)) {
-                /* Nested authentication. */
-                uint8_t SectorAddress;
-                uint8_t KeyOffset = (Buffer[0] == CMD_AUTH_A ? MEM_KEY_A_OFFSET : MEM_KEY_B_OFFSET);
-                /* Fix for MFClassic 4k cards */
-                if(Buffer[1] >= 128) {
-                    SectorAddress = Buffer[1] & MEM_BIGSECTOR_ADDR_MASK;
-                    KeyOffset += MEM_KEY_BIGSECTOR_OFFSET;
-                } else {
-                    SectorAddress = Buffer[1] & MEM_SECTOR_ADDR_MASK;
-                }
-                uint16_t KeyAddress = (uint16_t) SectorAddress * MEM_BYTES_PER_BLOCK + KeyOffset;
-                uint8_t Key[6];
-                uint8_t Uid[4];
-				uint8_t CardNonce[4] = {0x01};
-				uint8_t CardNonceParity[4];
-
-                /* Generate a random nonce and read UID and key from memory */
-                //RandomGetBuffer(CardNonce, sizeof(CardNonce));
-                if (_7BUID)
-					MemoryReadBlock(Uid, MEM_UID_CL2_ADDRESS, MEM_UID_CL2_SIZE);
-                else
-                    MemoryReadBlock(Uid, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
-
-                MemoryReadBlock(Key, KeyAddress, MEM_KEY_SIZE);
-
-                /* Precalculate the reader response from card-nonce */
-                for (uint8_t i=0; i<sizeof(ReaderResponse); i++)
-                    ReaderResponse[i] = CardNonce[i];
-
-                Crypto1PRNG(ReaderResponse, 64);
-
-                /* Precalculate our response from the reader response */
-                for (uint8_t i=0; i<sizeof(CardResponse); i++)
-                    CardResponse[i] = ReaderResponse[i];
-
-                Crypto1PRNG(CardResponse, 32);
-
-                /* Setup crypto1 cipher for nested authentication. */
-                Crypto1Setup(Key, Uid, CardNonce, CardNonceParity);
-
-                for (uint8_t i=0; i<sizeof(CardNonce); i++) {
-                    Buffer[i] = CardNonce[i];
-                    Buffer[ISO14443A_BUFFER_PARITY_OFFSET + i] = CardNonceParity[i];
-                }
-
-                /* Respond with the encrypted random card nonce and expect further authentication
-                * form the reader in the next frame. */
-                State = STATE_AUTHING;
-
-                return (CMD_AUTH_RB_FRAME_SIZE * BITS_PER_BYTE) | ISO14443A_APP_CUSTOM_PARITY;
-            } else {
-                Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-                return ACK_NAK_FRAME_SIZE;
-            }
-        } else {
-            /* Unknown command. Enter HALT state */
-            State = STATE_IDLE;
-        }
-
-        break;
-
-    case STATE_WRITE:
-        /* The reader has issued a write command earlier and is now
-         * sending the data to be written. Decrypt the data first and
-         * check for CRC. Then write the data when ReadOnly mode is not
-         * activated. */
-
-        /* We receive 16 bytes of data to be written and 2 bytes CRCA. Decrypt */
-        for (uint8_t i=0; i<(MEM_BYTES_PER_BLOCK + ISO14443A_CRCA_SIZE); i++)
-            Buffer[i] ^= Crypto1Byte();
-
-        if (ISO14443ACheckCRCA(Buffer, MEM_BYTES_PER_BLOCK)) {
-            if (!ActiveConfiguration.ReadOnly) {
-                MemoryWriteBlock(Buffer, CurrentAddress * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
-            } else {
-                /* Silently ignore in ReadOnly mode */
-            }
-
-            Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
-        } else {
-            Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-        }
-
-        State = STATE_AUTHED_IDLE;
-        return ACK_NAK_FRAME_SIZE;
-
-    case STATE_DECREMENT:
-    case STATE_INCREMENT:
-    case STATE_RESTORE:
-        /* When we reach here, a decrement, increment or restore command has
-         * been issued earlier and the reader is now sending the data. First,
-         * decrypt the data and check CRC. Read data from the requested block
-         * address into the global block buffer and check for integrity. Then
-         * add or subtract according to issued command if necessary and store
-         * the block back into the global block buffer. */
-        for (uint8_t i=0; i<(MEM_VALUE_SIZE  + ISO14443A_CRCA_SIZE); i++)
-            Buffer[i] ^= Crypto1Byte();
-
-        if (ISO14443ACheckCRCA(Buffer, MEM_VALUE_SIZE )) {
-            MemoryReadBlock(BlockBuffer, (uint16_t) CurrentAddress * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
-
-            if (CheckValueIntegrity(BlockBuffer)) {
-                uint32_t ParamValue;
-                uint32_t BlockValue;
-
-                ValueFromBlock(&ParamValue, Buffer);
-                ValueFromBlock(&BlockValue, BlockBuffer);
-
-                if (State == STATE_DECREMENT) {
-                    BlockValue -= ParamValue;
-                } else if (State == STATE_INCREMENT) {
-                    BlockValue += ParamValue;
-                } else if (State == STATE_RESTORE) {
-                    /* Do nothing */
-                }
-
-                ValueToBlock(BlockBuffer, BlockValue);
-
                 State = STATE_AUTHED_IDLE;
-                /* No ACK response on value commands part 2 */
-                return ISO14443A_APP_NO_RESPONSE;
+                ret = (CMD_AUTH_BA_FRAME_SIZE * BITS_PER_BYTE) | ISO14443A_APP_CUSTOM_PARITY;
             } else {
-                /* Not sure if this is the correct error code.. */
-                Buffer[0] = NAK_OTHER_ERROR ^ Crypto1Nibble();
+                /* Just reset on authentication error. */
+                State = STATE_IDLE;
+                Buffer[0] = NAK_S50_BUFFERKO_OPKO;
+                ret = ACK_NAK_FRAME_SIZE;
             }
-        } else {
-            /* CRC Error. */
-            Buffer[0] = NAK_CRC_ERROR ^ Crypto1Nibble();
-        }
+            break;
 
-        State = STATE_AUTHED_IDLE;
-        return ACK_NAK_FRAME_SIZE;
-        break;
+        case STATE_AUTHED_IDLE:
+            /* If something went wrong the reader might send an unencrypted halt */
+            if (Buffer[0] == CMD_HALT) {
+                ret = mfcHandleHaltCommand(Buffer);
+            } else {
+                /* In this state, all communication is encrypted. Thus we first have to decrypt
+                * the incoming data */
+                for (uint8_t i=0; i<4; i++) {
+                    Buffer[i] ^= Crypto1Byte();
+                }
+                /* All possible operations at this state have all same frame size, so we do
+                * CRC check first */
+                if ( !ISO14443ACheckCRCA(Buffer, CMD_COMMON_FRAME_SIZE) ) {
+                    Buffer[0] = NAK_S50_BUFFERKO_PARITYCRC ^ Crypto1Nibble();
+                    ret = ACK_NAK_FRAME_SIZE;
+                /* If CRC is valid we continue, with CRC passed */
+                } else {
+                    /* Read operation */
+                    if (Buffer[0] == CMD_READ) {
+                        /* Read command. Read data from memory and append CRCA */
+                        MemoryReadBlock(Buffer, (uint16_t) Buffer[1] * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
+                        ISO14443AAppendCRCA(Buffer, MEM_BYTES_PER_BLOCK);
+                        /* Encrypt and calculate parity bits. */
+                        for (uint8_t i=0; i<(ISO14443A_CRCA_SIZE + MEM_BYTES_PER_BLOCK); i++) {
+                            uint8_t Plain = Buffer[i];
+                            Buffer[i] = Plain ^ Crypto1Byte();
+                            Buffer[ISO14443A_BUFFER_PARITY_OFFSET + i] = ODD_PARITY(Plain) ^ Crypto1FilterOutput();
+                        }
+                        ret = ((CMD_READ_RESPONSE_FRAME_SIZE + ISO14443A_CRCA_SIZE) * BITS_PER_BYTE) | ISO14443A_APP_CUSTOM_PARITY;
+                    /* Write-type operation request */
+                    } else if ( (Buffer[0] == CMD_WRITE) || (Buffer[0] == CMD_TRANSFER) ) {
+                        /* Get target address. Write-type ops have address as 1st argument */
+                        CurrentAddress = Buffer[1];
+                        /* We deny any write-type operation to Block0 / Sector0 */
+                        if (CurrentAddress == MEM_S0B0_ADDRESS) {
+                            State = STATE_HALT;
+                            Buffer[0] = NAK_S50_BUFFEROK_OPKO ^ Crypto1Nibble();
+                        } else if (Buffer[0] == CMD_WRITE) {
+                            /* Write command. Store the address and prepare for the upcoming data.
+                            * Respond with ACK. */
+                            State = STATE_WRITE;
+                            Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
+                        } else if (Buffer[0] == CMD_TRANSFER) {
+                            /* Write back the global block buffer to the desired block address */
+                            if (!ActiveConfiguration.ReadOnly) {
+                                MemoryWriteBlock(BlockBuffer, (uint16_t) Buffer[1] * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
+                            } else {
+                                /* In read only mode, silently ignore the write */
+                            }
+                            Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
+                        }
+                        ret = ACK_NAK_FRAME_SIZE;
+                    } else if (Buffer[0] == CMD_DECREMENT) {
+                        State = STATE_DECREMENT;
+                        Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
+                        ret = ACK_NAK_FRAME_SIZE;
+                    } else if (Buffer[0] == CMD_INCREMENT) {
+                        State = STATE_INCREMENT;
+                        Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
+                        ret = ACK_NAK_FRAME_SIZE;
+                    } else if (Buffer[0] == CMD_RESTORE) {
+                        State = STATE_RESTORE;
+                        Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
+                        ret = ACK_NAK_FRAME_SIZE;
+                    } else if ( (Buffer[0] == CMD_AUTH_A) || (Buffer[0] == CMD_AUTH_B) ) {
+                        /* Nested authentication. */
+                        uint8_t SectorAddress;
+                        uint8_t KeyOffset = (Buffer[0] == CMD_AUTH_A ? MEM_KEY_A_OFFSET : MEM_KEY_B_OFFSET);
+                        /* Fix for MFClassic 4k cards */
+                        if (Buffer[1] >= 128) {
+                            SectorAddress = Buffer[1] & MEM_BIGSECTOR_ADDR_MASK;
+                            KeyOffset += MEM_KEY_BIGSECTOR_OFFSET;
+                        } else {
+                            SectorAddress = Buffer[1] & MEM_SECTOR_ADDR_MASK;
+                        }
+                        uint16_t KeyAddress = (uint16_t) SectorAddress * MEM_BYTES_PER_BLOCK + KeyOffset;
+                        uint8_t Key[6];
+                        uint8_t Uid[4];
+                        uint8_t CardNonce[4] = {0x01};
+                        uint8_t CardNonceParity[4];
+                        /* Read UID and key from memory */
+                        if (is7BitsUID) {
+                            MemoryReadBlock(Uid, MEM_UID_CL2_ADDRESS, MEM_UID_CL2_SIZE);
+                        } else {
+                            MemoryReadBlock(Uid, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
+                        }
+                        MemoryReadBlock(Key, KeyAddress, MEM_KEY_SIZE);
+                        /* Precalculate the reader response from card-nonce */
+                        for (uint8_t i=0; i<sizeof(ReaderResponse); i++) {
+                            ReaderResponse[i] = CardNonce[i];
+                        }
+                        Crypto1PRNG(ReaderResponse, 64);
+                        /* Precalculate our response from the reader response */
+                        for (uint8_t i=0; i<sizeof(CardResponse); i++) {
+                            CardResponse[i] = ReaderResponse[i];
+                        }
+                        Crypto1PRNG(CardResponse, 32);
+                        /* Setup crypto1 cipher for nested authentication. */
+                        Crypto1Setup(Key, Uid, CardNonce, CardNonceParity);
+                        for (uint8_t i=0; i<sizeof(CardNonce); i++) {
+                            Buffer[i] = CardNonce[i];
+                            Buffer[ISO14443A_BUFFER_PARITY_OFFSET + i] = CardNonceParity[i];
+                        }
+                        /* Respond with the encrypted random card nonce and expect further authentication
+                        * form the reader in the next frame. */
+                        State = STATE_AUTHING;
+                        ret = (CMD_AUTH_RB_FRAME_SIZE * BITS_PER_BYTE) | ISO14443A_APP_CUSTOM_PARITY;
+                    } else {
+                        /* Unknown command. Enter HALT state */
+                        /* Just reset on authentication error. */
+                        State = STATE_IDLE;
+                        Buffer[0] = NAK_S50_BUFFERKO_OPKO;
+                        ret = ACK_NAK_FRAME_SIZE;
+                    }
+                }
+            }
+            break;
 
+        case STATE_WRITE:
+            /* The reader has issued a write command earlier and is now
+             * sending the data to be written. Decrypt the data first and
+             * check for CRC. Then write the data when ReadOnly mode is not
+             * activated. */
+            /* We receive 16 bytes of data to be written and 2 bytes CRCA. Decrypt */
+            for (uint8_t i=0; i<(MEM_BYTES_PER_BLOCK + ISO14443A_CRCA_SIZE); i++) {
+                Buffer[i] ^= Crypto1Byte();
+            }
+            if (ISO14443ACheckCRCA(Buffer, MEM_BYTES_PER_BLOCK)) {
+                if (!ActiveConfiguration.ReadOnly) {
+                    MemoryWriteBlock(Buffer, CurrentAddress * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
+                } else {
+                    /* Silently ignore in ReadOnly mode */
+                }
 
-    default:
-        /* Unknown state? Should never happen. */
-        break;
-    }
+                Buffer[0] = ACK_VALUE ^ Crypto1Nibble();
+            } else {
+                Buffer[0] = NAK_S50_BUFFERKO_PARITYCRC ^ Crypto1Nibble();
+            }
+            State = STATE_AUTHED_IDLE;
+            ret = ACK_NAK_FRAME_SIZE;
+            break;
 
-    /* No response has been sent, when we reach here */
-    return ISO14443A_APP_NO_RESPONSE;
+        case STATE_DECREMENT:
+        case STATE_INCREMENT:
+        case STATE_RESTORE:
+            /* When we reach here, a decrement, increment or restore command has
+             * been issued earlier and the reader is now sending the data. First,
+             * decrypt the data and check CRC. Read data from the requested block
+             * address into the global block buffer and check for integrity. Then
+             * add or subtract according to issued command if necessary and store
+             * the block back into the global block buffer. */
+            for (uint8_t i=0; i<(MEM_VALUE_SIZE  + ISO14443A_CRCA_SIZE); i++) {
+                Buffer[i] ^= Crypto1Byte();
+            }
+            if (ISO14443ACheckCRCA(Buffer, MEM_VALUE_SIZE )) {
+                MemoryReadBlock(BlockBuffer, (uint16_t) CurrentAddress * MEM_BYTES_PER_BLOCK, MEM_BYTES_PER_BLOCK);
+                if (CheckValueIntegrity(BlockBuffer)) {
+                    uint32_t ParamValue;
+                    uint32_t BlockValue;
+                    ValueFromBlock(&ParamValue, Buffer);
+                    ValueFromBlock(&BlockValue, BlockBuffer);
+                    if (State == STATE_DECREMENT) {
+                        BlockValue -= ParamValue;
+                    } else if (State == STATE_INCREMENT) {
+                        BlockValue += ParamValue;
+                    }
+                    ValueToBlock(BlockBuffer, BlockValue);
+                    State = STATE_AUTHED_IDLE;
+                    /* No ACK response on value commands part 2 */
+                    ret = ISO14443A_APP_NO_RESPONSE;
+                } else {
+                    Buffer[0] = NAK_S50_BUFFEROK_PARITYCRC ^ Crypto1Nibble();
+                }
+            } else {
+                Buffer[0] = NAK_S50_BUFFERKO_PARITYCRC ^ Crypto1Nibble();
+            }
+            State = STATE_AUTHED_IDLE;
+            ret = ACK_NAK_FRAME_SIZE;
+            break;
+
+        default:
+            /* Unknown state should never happen. Fail. */
+            ret = ISO14443A_APP_NO_RESPONSE;
+        } /* END OF SWITCH CASE */
+    } /* END OF ISO14443AWakeUp CONDITION */
+    return ret;
 }
 
 void MifareClassicGetUid(ConfigurationUidType Uid)
 {
-	if (_7BUID) {
-		//Uid[0]=0x88;
-		MemoryReadBlock(&Uid[0], MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE-1);
-		MemoryReadBlock(&Uid[3], MEM_UID_CL2_ADDRESS, MEM_UID_CL2_SIZE);
-	} else {
+    if (is7BitsUID) {
+        MemoryReadBlock(&Uid[0], MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE-1);
+        MemoryReadBlock(&Uid[3], MEM_UID_CL2_ADDRESS, MEM_UID_CL2_SIZE);
+    } else {
         MemoryReadBlock(Uid, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
-	}
+    }
 }
 
 void MifareClassicSetUid(ConfigurationUidType Uid)
 {
-    if (_7BUID) {
-	    //Uid[0]=0x88;
-	    MemoryWriteBlock(Uid, MEM_UID_CL1_ADDRESS, ActiveConfiguration.UidSize);
+    if (is7BitsUID) {
+        MemoryWriteBlock(Uid, MEM_UID_CL1_ADDRESS, ActiveConfiguration.UidSize);
     } else {
         uint8_t BCC =  Uid[0] ^ Uid[1] ^ Uid[2] ^ Uid[3];
-		MemoryWriteBlock(Uid, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
+        MemoryWriteBlock(Uid, MEM_UID_CL1_ADDRESS, MEM_UID_CL1_SIZE);
         MemoryWriteBlock(&BCC, MEM_UID_BCC1_ADDRESS, ISO14443A_CL_BCC_SIZE);
     }
 }
 
 void MifareClassicGetAtqa(uint16_t * Atqa)
 {
-	*Atqa = CardATQAValue;
+    *Atqa = CardATQAValue;
 }
 
 void MifareClassicSetAtqa(uint16_t Atqa)
 {
-	CardATQAValue = Atqa;
+    CardATQAValue = Atqa;
 }
 
 void MifareClassicGetSak(uint8_t * Sak)
 {
-	*Sak = CardSAKValue;
+    *Sak = CardSAKValue;
 }
 
 void MifareClassicSetSak(uint8_t Sak)
 {
-	CardSAKValue = Sak;
+    CardSAKValue = Sak;
 }

--- a/Firmware/Chameleon-Mini/Application/MifareClassic.c
+++ b/Firmware/Chameleon-Mini/Application/MifareClassic.c
@@ -13,8 +13,10 @@
 #include "Crypto1.h"
 
 #define MFCLASSIC_1K_ATQA_VALUE     0x0004
-#define MFPlus_ATQA_VALUE           0x0044
 #define MFCLASSIC_4K_ATQA_VALUE     0x0002
+#define MFCLASSIC_1K_7B_ATQA_VALUE  0x0044
+#define MFCLASSIC_4K_ATQA_VALUE     0x0002
+#define MFCLASSIC_4K_7B_ATQA_VALUE  0x0042
 #define MFCLASSIC_1K_SAK_CL1_VALUE  0x08
 #define MFCLASSIC_4K_SAK_CL1_VALUE  0x18
 #define SAK_CL1_VALUE               ISO14443A_SAK_INCOMPLETE
@@ -393,26 +395,25 @@ INLINE void ValueToBlock(uint8_t* Block, uint32_t Value)
 void MifareClassicAppInit1K(void)
 {
     State = STATE_IDLE;
-    CardATQAValue = MFCLASSIC_1K_ATQA_VALUE;
+    is7BitsUID = (ActiveConfiguration.UidSize == MEM_UID7_SIZE);
+    if (is7BitsUID) {
+        CardATQAValue = MFCLASSIC_1K_ATQA_VALUE;
+    } else {
+        CardATQAValue = MFCLASSIC_1K_7B_ATQA_VALUE;
+    }
     CardSAKValue = MFCLASSIC_1K_SAK_CL1_VALUE;
-    is7BitsUID = false;
-}
-
-void MifarePlus1kAppInit_7B(void)
-{
-    State = STATE_IDLE;
-    CardATQAValue = MFPlus_ATQA_VALUE;
-    CardSAKValue = MFCLASSIC_1K_SAK_CL1_VALUE;
-    uint8_t UidSize = ActiveConfiguration.UidSize;
-    is7BitsUID = (UidSize == MEM_UID7_SIZE);
 }
 
 void MifareClassicAppInit4K(void)
 {
     State = STATE_IDLE;
-    CardATQAValue = MFCLASSIC_4K_ATQA_VALUE;
+    is7BitsUID = (ActiveConfiguration.UidSize == MEM_UID7_SIZE);
+    if (is7BitsUID) {
+        CardATQAValue = MFCLASSIC_4K_ATQA_VALUE;
+    } else {
+        CardATQAValue = MFCLASSIC_4K_7B_ATQA_VALUE;
+    }
     CardSAKValue = MFCLASSIC_4K_SAK_CL1_VALUE;
-    is7BitsUID = false;
 }
 
 void MifareClassicAppReset(void)

--- a/Firmware/Chameleon-Mini/Application/MifareClassic.h
+++ b/Firmware/Chameleon-Mini/Application/MifareClassic.h
@@ -16,7 +16,6 @@
 #define MIFARE_CLASSIC_4K_MEM_SIZE  4096
 
 void MifareClassicAppInit1K(void);
-void MifarePlus1kAppInit_7B(void);
 void MifareClassicAppInit4K(void);
 void MifareClassicAppReset(void);
 void MifareClassicAppTask(void);

--- a/Firmware/Chameleon-Mini/Configuration.c
+++ b/Firmware/Chameleon-Mini/Configuration.c
@@ -13,26 +13,26 @@
 
 /* Map IDs to text */
 static const MapEntryType PROGMEM ConfigurationMap[] = {
-    { .Id = CONFIG_NONE, 			.Text = "CLOSED" },
+    { .Id = CONFIG_NONE,            .Text = "CLOSED" },
 #ifdef CONFIG_MF_ULTRALIGHT_SUPPORT
-    { .Id = CONFIG_MF_ULTRALIGHT, 	.Text = "MF_ULTRALIGHT" },
+    { .Id = CONFIG_MF_ULTRALIGHT,   .Text = "MF_ULTRALIGHT" },
     { .Id = CONFIG_MF_ULTRALIGHT_EV1_80B,   .Text = "MF_ULTRALIGHT_EV1_80B" },
     { .Id = CONFIG_MF_ULTRALIGHT_EV1_164B,   .Text = "MF_ULTRALIGHT_EV1_164B" },
 #endif
 #ifdef CONFIG_MF_CLASSIC_1K_SUPPORT
-    { .Id = CONFIG_MF_CLASSIC_1K, 	.Text = "MF_CLASSIC_1K" },
+    { .Id = CONFIG_MF_CLASSIC_1K,   .Text = "MF_CLASSIC_1K" },
 #endif
 #ifdef CONFIG_MF_CLASSIC_1K_7B_SUPPORT
-    { .Id = CONFIG_MF_CLASSIC_1K_7B, 	.Text = "MF_CLASSIC_1K_7B" },
+    { .Id = CONFIG_MF_CLASSIC_1K_7B,    .Text = "MF_CLASSIC_1K_7B" },
 #endif
 #ifdef CONFIG_MF_CLASSIC_4K_SUPPORT
-    { .Id = CONFIG_MF_CLASSIC_4K, 	.Text = "MF_CLASSIC_4K" },
+    { .Id = CONFIG_MF_CLASSIC_4K,   .Text = "MF_CLASSIC_4K" },
 #endif
 #ifdef CONFIG_MF_CLASSIC_4K_7B_SUPPORT
-    { .Id = CONFIG_MF_CLASSIC_4K_7B, 	.Text = "MF_CLASSIC_4K_7B" },
+    { .Id = CONFIG_MF_CLASSIC_4K_7B,    .Text = "MF_CLASSIC_4K_7B" },
 #endif
 #ifdef CONFIG_MF_DETECTION_SUPPORT
-	{ .Id = CONFIG_MF_DETECTION, 	.Text = "MF_DETECTION" },
+    { .Id = CONFIG_MF_DETECTION,    .Text = "MF_DETECTION" },
 #endif
 };
 
@@ -55,178 +55,178 @@ static void ApplicationGetSakDummy(uint8_t * Atqa) { }
 static void ApplicationSetSakDummy(uint8_t Atqa) { }
 
 static const PROGMEM ConfigurationType ConfigurationTable[] = {
-    [CONFIG_NONE] = {
-        .CodecInitFunc = CodecInitDummy,
-        .CodecTaskFunc = CodecTaskDummy,
-        .ApplicationInitFunc = ApplicationInitDummy,
-        .ApplicationResetFunc = ApplicationResetDummy,
-        .ApplicationTaskFunc = ApplicationTaskDummy,
-        .ApplicationTickFunc = ApplicationTickDummy,
-        .ApplicationProcessFunc = ApplicationProcessDummy,
-        .ApplicationGetUidFunc = ApplicationGetUidDummy,
-        .ApplicationSetUidFunc = ApplicationSetUidDummy,
-        .ApplicationGetSakFunc = ApplicationGetSakDummy,
-        .ApplicationSetSakFunc = ApplicationSetSakDummy,
-        .ApplicationGetAtqaFunc = ApplicationGetAtqaDummy,
-        .ApplicationSetAtqaFunc = ApplicationSetAtqaDummy,
-        .UidSize = MIFARE_CLASSIC_UID_SIZE,
-        .MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
-        .ReadOnly = true
-    },
+[CONFIG_NONE] = {
+    .CodecInitFunc = CodecInitDummy,
+    .CodecTaskFunc = CodecTaskDummy,
+    .ApplicationInitFunc = ApplicationInitDummy,
+    .ApplicationResetFunc = ApplicationResetDummy,
+    .ApplicationTaskFunc = ApplicationTaskDummy,
+    .ApplicationTickFunc = ApplicationTickDummy,
+    .ApplicationProcessFunc = ApplicationProcessDummy,
+    .ApplicationGetUidFunc = ApplicationGetUidDummy,
+    .ApplicationSetUidFunc = ApplicationSetUidDummy,
+    .ApplicationGetSakFunc = ApplicationGetSakDummy,
+    .ApplicationSetSakFunc = ApplicationSetSakDummy,
+    .ApplicationGetAtqaFunc = ApplicationGetAtqaDummy,
+    .ApplicationSetAtqaFunc = ApplicationSetAtqaDummy,
+    .UidSize = MIFARE_CLASSIC_UID_SIZE,
+    .MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
+    .ReadOnly = true
+},
 #ifdef CONFIG_MF_ULTRALIGHT_SUPPORT
 [CONFIG_MF_ULTRALIGHT] = {
-	.CodecInitFunc = ISO14443ACodecInit,
-	.CodecTaskFunc = ISO14443ACodecTask,
-	.ApplicationInitFunc = MifareUltralightAppInit,
-	.ApplicationResetFunc = MifareUltralightAppReset,
-	.ApplicationTaskFunc = MifareUltralightAppTask,
+    .CodecInitFunc = ISO14443ACodecInit,
+    .CodecTaskFunc = ISO14443ACodecTask,
+    .ApplicationInitFunc = MifareUltralightAppInit,
+    .ApplicationResetFunc = MifareUltralightAppReset,
+    .ApplicationTaskFunc = MifareUltralightAppTask,
     .ApplicationTickFunc = ApplicationTickDummy,
-	.ApplicationProcessFunc = MifareUltralightAppProcess,
-	.ApplicationGetUidFunc = MifareUltralightGetUid,
-	.ApplicationSetUidFunc = MifareUltralightSetUid,
+    .ApplicationProcessFunc = MifareUltralightAppProcess,
+    .ApplicationGetUidFunc = MifareUltralightGetUid,
+    .ApplicationSetUidFunc = MifareUltralightSetUid,
     .ApplicationGetSakFunc = MifareUltralightGetSak,
     .ApplicationSetSakFunc = MifareUltralightSetSak,
     .ApplicationGetAtqaFunc = MifareUltralightGetAtqa,
     .ApplicationSetAtqaFunc = MifareUltralightSetAtqa,
-	.UidSize = MIFARE_ULTRALIGHT_UID_SIZE,
-	.MemorySize = MIFARE_ULTRALIGHT_MEM_SIZE,
-	.ReadOnly = false
+    .UidSize = MIFARE_ULTRALIGHT_UID_SIZE,
+    .MemorySize = MIFARE_ULTRALIGHT_MEM_SIZE,
+    .ReadOnly = false
 },
 [CONFIG_MF_ULTRALIGHT_EV1_80B] = {
-	.CodecInitFunc = ISO14443ACodecInit,
-	.CodecTaskFunc = ISO14443ACodecTask,
-	.ApplicationInitFunc = MifareUltralightEV11AppInit,
-	.ApplicationResetFunc = MifareUltralightAppReset,
-	.ApplicationTaskFunc = MifareUltralightAppTask,
-	.ApplicationTickFunc = ApplicationTickDummy,
-	.ApplicationProcessFunc = MifareUltralightAppProcess,
-	.ApplicationGetUidFunc = MifareUltralightGetUid,
-	.ApplicationSetUidFunc = MifareUltralightSetUid,
+    .CodecInitFunc = ISO14443ACodecInit,
+    .CodecTaskFunc = ISO14443ACodecTask,
+    .ApplicationInitFunc = MifareUltralightEV11AppInit,
+    .ApplicationResetFunc = MifareUltralightAppReset,
+    .ApplicationTaskFunc = MifareUltralightAppTask,
+    .ApplicationTickFunc = ApplicationTickDummy,
+    .ApplicationProcessFunc = MifareUltralightAppProcess,
+    .ApplicationGetUidFunc = MifareUltralightGetUid,
+    .ApplicationSetUidFunc = MifareUltralightSetUid,
     .ApplicationGetSakFunc = MifareUltralightGetSak,
     .ApplicationSetSakFunc = MifareUltralightSetSak,
     .ApplicationGetAtqaFunc = MifareUltralightGetAtqa,
     .ApplicationSetAtqaFunc = MifareUltralightSetAtqa,
-	.UidSize = MIFARE_ULTRALIGHT_UID_SIZE,
-	.MemorySize = MIFARE_ULTRALIGHT_EV11_MEM_SIZE,
-	.ReadOnly = false
+    .UidSize = MIFARE_ULTRALIGHT_UID_SIZE,
+    .MemorySize = MIFARE_ULTRALIGHT_EV11_MEM_SIZE,
+    .ReadOnly = false
 },
 [CONFIG_MF_ULTRALIGHT_EV1_164B] = {
-	.CodecInitFunc = ISO14443ACodecInit,
-	.CodecTaskFunc = ISO14443ACodecTask,
-	.ApplicationInitFunc = MifareUltralightEV12AppInit,
-	.ApplicationResetFunc = MifareUltralightAppReset,
-	.ApplicationTaskFunc = MifareUltralightAppTask,
-	.ApplicationTickFunc = ApplicationTickDummy,
-	.ApplicationProcessFunc = MifareUltralightAppProcess,
-	.ApplicationGetUidFunc = MifareUltralightGetUid,
-	.ApplicationSetUidFunc = MifareUltralightSetUid,
+    .CodecInitFunc = ISO14443ACodecInit,
+    .CodecTaskFunc = ISO14443ACodecTask,
+    .ApplicationInitFunc = MifareUltralightEV12AppInit,
+    .ApplicationResetFunc = MifareUltralightAppReset,
+    .ApplicationTaskFunc = MifareUltralightAppTask,
+    .ApplicationTickFunc = ApplicationTickDummy,
+    .ApplicationProcessFunc = MifareUltralightAppProcess,
+    .ApplicationGetUidFunc = MifareUltralightGetUid,
+    .ApplicationSetUidFunc = MifareUltralightSetUid,
     .ApplicationGetSakFunc = MifareUltralightGetSak,
     .ApplicationSetSakFunc = MifareUltralightSetSak,
     .ApplicationGetAtqaFunc = MifareUltralightGetAtqa,
     .ApplicationSetAtqaFunc = MifareUltralightSetAtqa,
-	.UidSize = MIFARE_ULTRALIGHT_UID_SIZE,
-	.MemorySize = MIFARE_ULTRALIGHT_EV12_MEM_SIZE,
-	.ReadOnly = false
+    .UidSize = MIFARE_ULTRALIGHT_UID_SIZE,
+    .MemorySize = MIFARE_ULTRALIGHT_EV12_MEM_SIZE,
+    .ReadOnly = false
 },
 #endif
 #ifdef CONFIG_MF_CLASSIC_1K_SUPPORT
-    [CONFIG_MF_CLASSIC_1K] = {
-        .CodecInitFunc = ISO14443ACodecInit,
-        .CodecTaskFunc = ISO14443ACodecTask,
-        .ApplicationInitFunc = MifareClassicAppInit1K,
-        .ApplicationResetFunc = MifareClassicAppReset,
-        .ApplicationTaskFunc = MifareClassicAppTask,
-        .ApplicationTickFunc = ApplicationTickDummy,
-        .ApplicationProcessFunc = MifareClassicAppProcess,
-        .ApplicationGetUidFunc = MifareClassicGetUid,
-        .ApplicationSetUidFunc = MifareClassicSetUid,
-        .ApplicationGetSakFunc = MifareClassicGetSak,
-        .ApplicationSetSakFunc = MifareClassicSetSak,
-        .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
-        .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
-        .UidSize = MIFARE_CLASSIC_UID_SIZE,
-        .MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
-        .ReadOnly = false
-    },
-#endif
-#ifdef CONFIG_MF_CLASSIC_1K_7B_SUPPORT
-    [CONFIG_MF_CLASSIC_1K_7B] = {
-        .CodecInitFunc = ISO14443ACodecInit,
-        .CodecTaskFunc = ISO14443ACodecTask,
-        .ApplicationInitFunc = MifarePlus1kAppInit_7B,
-        .ApplicationResetFunc = MifareClassicAppReset,
-        .ApplicationTaskFunc = MifareClassicAppTask,
-        .ApplicationTickFunc = ApplicationTickDummy,
-        .ApplicationProcessFunc = MifareClassicAppProcess,
-        .ApplicationGetUidFunc = MifareClassicGetUid,
-        .ApplicationSetUidFunc = MifareClassicSetUid,
-        .ApplicationGetSakFunc = MifareClassicGetSak,
-        .ApplicationSetSakFunc = MifareClassicSetSak,
-        .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
-        .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
-        .UidSize = ISO14443A_UID_SIZE_DOUBLE,
-        .MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
-        .ReadOnly = false
-    },
-#endif
-#ifdef CONFIG_MF_CLASSIC_4K_SUPPORT
-    [CONFIG_MF_CLASSIC_4K] = {
-        .CodecInitFunc = ISO14443ACodecInit,
-        .CodecTaskFunc = ISO14443ACodecTask,
-        .ApplicationInitFunc = MifareClassicAppInit4K,
-        .ApplicationResetFunc = MifareClassicAppReset,
-        .ApplicationTaskFunc = MifareClassicAppTask,
-        .ApplicationTickFunc = ApplicationTickDummy,
-        .ApplicationProcessFunc = MifareClassicAppProcess,
-        .ApplicationGetUidFunc = MifareClassicGetUid,
-        .ApplicationSetUidFunc = MifareClassicSetUid,
-        .ApplicationGetSakFunc = MifareClassicGetSak,
-        .ApplicationSetSakFunc = MifareClassicSetSak,
-        .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
-        .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
-        .UidSize = MIFARE_CLASSIC_UID_SIZE,
-        .MemorySize = MIFARE_CLASSIC_4K_MEM_SIZE,
-        .ReadOnly = false
-    },
-#endif
-#ifdef CONFIG_MF_CLASSIC_4K_7B_SUPPORT
-[CONFIG_MF_CLASSIC_4K_7B] = {
-	.CodecInitFunc = ISO14443ACodecInit,
-	.CodecTaskFunc = ISO14443ACodecTask,
-	.ApplicationInitFunc = MifareClassicAppInit4K7B,
-	.ApplicationResetFunc = MifareClassicAppReset,
-	.ApplicationTaskFunc = MifareClassicAppTask,
-	.ApplicationTickFunc = ApplicationTickDummy,
-	.ApplicationProcessFunc = MifareClassicAppProcess,
-	.ApplicationGetUidFunc = MifareClassicGetUid,
-	.ApplicationSetUidFunc = MifareClassicSetUid,
+[CONFIG_MF_CLASSIC_1K] = {
+    .CodecInitFunc = ISO14443ACodecInit,
+    .CodecTaskFunc = ISO14443ACodecTask,
+    .ApplicationInitFunc = MifareClassicAppInit1K,
+    .ApplicationResetFunc = MifareClassicAppReset,
+    .ApplicationTaskFunc = MifareClassicAppTask,
+    .ApplicationTickFunc = ApplicationTickDummy,
+    .ApplicationProcessFunc = MifareClassicAppProcess,
+    .ApplicationGetUidFunc = MifareClassicGetUid,
+    .ApplicationSetUidFunc = MifareClassicSetUid,
     .ApplicationGetSakFunc = MifareClassicGetSak,
     .ApplicationSetSakFunc = MifareClassicSetSak,
     .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
     .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
-	.UidSize = ISO14443A_UID_SIZE_DOUBLE,
-	.MemorySize = MIFARE_CLASSIC_4K_MEM_SIZE,
-	.ReadOnly = false
+    .UidSize = MIFARE_CLASSIC_UID_SIZE,
+    .MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
+    .ReadOnly = false
+},
+#endif
+#ifdef CONFIG_MF_CLASSIC_1K_7B_SUPPORT
+[CONFIG_MF_CLASSIC_1K_7B] = {
+    .CodecInitFunc = ISO14443ACodecInit,
+    .CodecTaskFunc = ISO14443ACodecTask,
+    .ApplicationInitFunc = MifareClassicAppInit1K,
+    .ApplicationResetFunc = MifareClassicAppReset,
+    .ApplicationTaskFunc = MifareClassicAppTask,
+    .ApplicationTickFunc = ApplicationTickDummy,
+    .ApplicationProcessFunc = MifareClassicAppProcess,
+    .ApplicationGetUidFunc = MifareClassicGetUid,
+    .ApplicationSetUidFunc = MifareClassicSetUid,
+    .ApplicationGetSakFunc = MifareClassicGetSak,
+    .ApplicationSetSakFunc = MifareClassicSetSak,
+    .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
+    .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
+    .UidSize = ISO14443A_UID_SIZE_DOUBLE,
+    .MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
+    .ReadOnly = false
+},
+#endif
+#ifdef CONFIG_MF_CLASSIC_4K_SUPPORT
+[CONFIG_MF_CLASSIC_4K] = {
+    .CodecInitFunc = ISO14443ACodecInit,
+    .CodecTaskFunc = ISO14443ACodecTask,
+    .ApplicationInitFunc = MifareClassicAppInit4K,
+    .ApplicationResetFunc = MifareClassicAppReset,
+    .ApplicationTaskFunc = MifareClassicAppTask,
+    .ApplicationTickFunc = ApplicationTickDummy,
+    .ApplicationProcessFunc = MifareClassicAppProcess,
+    .ApplicationGetUidFunc = MifareClassicGetUid,
+    .ApplicationSetUidFunc = MifareClassicSetUid,
+    .ApplicationGetSakFunc = MifareClassicGetSak,
+    .ApplicationSetSakFunc = MifareClassicSetSak,
+    .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
+    .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
+    .UidSize = MIFARE_CLASSIC_UID_SIZE,
+    .MemorySize = MIFARE_CLASSIC_4K_MEM_SIZE,
+    .ReadOnly = false
+},
+#endif
+#ifdef CONFIG_MF_CLASSIC_4K_7B_SUPPORT
+[CONFIG_MF_CLASSIC_4K_7B] = {
+    .CodecInitFunc = ISO14443ACodecInit,
+    .CodecTaskFunc = ISO14443ACodecTask,
+    .ApplicationInitFunc = MifareClassicAppInit4K,
+    .ApplicationResetFunc = MifareClassicAppReset,
+    .ApplicationTaskFunc = MifareClassicAppTask,
+    .ApplicationTickFunc = ApplicationTickDummy,
+    .ApplicationProcessFunc = MifareClassicAppProcess,
+    .ApplicationGetUidFunc = MifareClassicGetUid,
+    .ApplicationSetUidFunc = MifareClassicSetUid,
+    .ApplicationGetSakFunc = MifareClassicGetSak,
+    .ApplicationSetSakFunc = MifareClassicSetSak,
+    .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
+    .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
+    .UidSize = ISO14443A_UID_SIZE_DOUBLE,
+    .MemorySize = MIFARE_CLASSIC_4K_MEM_SIZE,
+    .ReadOnly = false
 },
 #endif
 #ifdef CONFIG_MF_DETECTION_SUPPORT
 [CONFIG_MF_DETECTION] = {
-	.CodecInitFunc = ISO14443ACodecInit,
-	.CodecTaskFunc = ISO14443ACodecTask,
-	.ApplicationInitFunc = MifareDetectionInit,
-	.ApplicationResetFunc = MifareDetectionReset,
-	.ApplicationTaskFunc = MifareClassicAppTask,
+    .CodecInitFunc = ISO14443ACodecInit,
+    .CodecTaskFunc = ISO14443ACodecTask,
+    .ApplicationInitFunc = MifareDetectionInit,
+    .ApplicationResetFunc = MifareDetectionReset,
+    .ApplicationTaskFunc = MifareClassicAppTask,
     .ApplicationTickFunc = ApplicationTickDummy,
-	.ApplicationProcessFunc = MifareDetectionAppProcess,
-	.ApplicationGetUidFunc = MifareClassicGetUid,
-	.ApplicationSetUidFunc = MifareClassicSetUid,
+    .ApplicationProcessFunc = MifareDetectionAppProcess,
+    .ApplicationGetUidFunc = MifareClassicGetUid,
+    .ApplicationSetUidFunc = MifareClassicSetUid,
     .ApplicationGetSakFunc = MifareClassicGetSak,
     .ApplicationSetSakFunc = MifareClassicSetSak,
     .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
     .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
-	.UidSize = MIFARE_CLASSIC_UID_SIZE,
-	.MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
-	.ReadOnly = false
+    .UidSize = MIFARE_CLASSIC_UID_SIZE,
+    .MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
+    .ReadOnly = false
 },
 #endif
 };
@@ -240,7 +240,7 @@ void ConfigurationInit(void)
 
 void ConfigurationSetById( ConfigurationEnum Configuration )
 {
-	GlobalSettings.ActiveSettingPtr->Configuration = Configuration;
+    GlobalSettings.ActiveSettingPtr->Configuration = Configuration;
 
     /* Copy struct from PROGMEM to RAM */
     memcpy_P(&ActiveConfiguration, &ConfigurationTable[Configuration], sizeof(ConfigurationType));
@@ -257,18 +257,18 @@ void ConfigurationGetByName(char* Configuration, uint16_t BufferSize)
 bool ConfigurationSetByName(const char* Configuration)
 {
     MapIdType Id;
-	
+
     if (MapTextToId(ConfigurationMap, ARRAY_COUNT(ConfigurationMap), Configuration, &Id)) {
 #ifdef CONFIG_MF_CLASSIC_4K_SUPPORT
-		if (Id == CONFIG_MF_CLASSIC_4K && GlobalSettings.ActiveSetting != 0)
-		{
-			return false;
-		}
+        if (Id == CONFIG_MF_CLASSIC_4K && GlobalSettings.ActiveSetting != 0)
+        {
+            return false;
+        }
 #endif
         ConfigurationSetById(Id);
         return true;
     } else {
-	return false;
+    return false;
     }
 }
 

--- a/Firmware/Chameleon-Mini/LED.h
+++ b/Firmware/Chameleon-Mini/LED.h
@@ -13,19 +13,19 @@
 #include <avr/io.h>
 
 #define LED_HIGH_PORT  PORTA
-#define LED_ONE	        PIN5_bm
-#define LED_TWO		    PIN4_bm
-#define LED_THREE		PIN3_bm
-#define LED_FOUR		PIN2_bm
-#define LED_HIGH_MASK	(LED_ONE | LED_TWO | LED_THREE| LED_FOUR)
+#define LED_ONE         PIN5_bm
+#define LED_TWO         PIN4_bm
+#define LED_THREE       PIN3_bm
+#define LED_FOUR        PIN2_bm
+#define LED_HIGH_MASK   (LED_ONE | LED_TWO | LED_THREE| LED_FOUR)
 
 #define LED_LOW_PORT    PORTE
-#define LED_FIVE	    PIN3_bm
-#define LED_SIX		    PIN2_bm
-#define LED_SEVEN		PIN1_bm
-#define LED_EIGHT		PIN0_bm
-#define LED_LOW_MASK	(LED_FIVE | LED_SIX | LED_SEVEN| LED_EIGHT)
-			
+#define LED_FIVE        PIN3_bm
+#define LED_SIX         PIN2_bm
+#define LED_SEVEN       PIN1_bm
+#define LED_EIGHT       PIN0_bm
+#define LED_LOW_MASK    (LED_FIVE | LED_SIX | LED_SEVEN| LED_EIGHT)
+
 void LEDMode(void);
 void LEDInit(void);
 void LEDTick(void);


### PR DESCRIPTION
A try at fixing writable Mifare block0 even if not in Chinese mode.
Worked well on MCT (block0 not writable, but others are).
Cannot really test more than MCT...
I also refactored and added comments to Mifare, added comments on ISO 14443 3A, and ensured spaces consistency in Mifare, ISO 14443 3A, and LED.h (WTF? Was included in MifareClassic.c?), in order to ease readability and prepare some future work.

While discovering MifareClassic.c code and testing this with proxmark3, I noticed those, unrelated to this PR:
- there are (possible) selection issues on RevE rebooted with latest-firmware proxmark3: I can do `hf 14a reader k 3` and read tag info, but not `hf search`, on RevE rebooted simulated Mifare dumps. This probably means crypto and/or anti collision recent commits on RevE rebooted, that definitely made it work on different real readers and MCT from my side, added some issues with proxmark3;
- access control on Mifare blocks is not implemented at all, as it looks;
- I still have an issue with a door-lock reader, which does not react at all with RevE rebooted. If I add a blank real Chinese card in front or behind the RevE, then door unlocks. RevE rebooted dump is correctly read.
So trying to fix writable block0, I mainly discovered there are still a lot to fix on Mifare. I'll try to work on those as next step.