### PR TITLE
Name unifying in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,63 +4,48 @@ ChameleonMini RevE - Rebooted
 | ------------------- |:-------------------:|
 | [![Build Status](https://travis-ci.org/iceman1001/ChameleonMini-rebooted.svg?branch=master)](https://travis-ci.org/iceman1001/ChameleonMini-rebooted) | [![Latest release](https://img.shields.io/github/release/iceman1001/ChameleonMini-rebooted.svg)](https://github.com/iceman1001/ChameleonMini-rebooted/releases/latest) |
 
-![Image chameleon mini revE - rebooted](http://www.icedev.se/chameleon_mini_revE/miniRevE.jpg)
+![Image ChameleonMini revE - rebooted](http://www.icedev.se/chameleon_mini_revE/miniRevE.jpg)
 
 # Attribution LICENSE
-"Based on the open-source NFC tool ChameleonMini:
-https://github.com/emsec/ChameleonMini"
+"Based on the open-source NFC tool ChameleonMini: https://github.com/emsec/ChameleonMini" [License](https://github.com/iceman1001/ChameleonMini-rebooted/blob/master/LICENSE.txt)
 
-[license](https://github.com/iceman1001/ChameleonMini-rebooted/blob/master/LICENSE.txt)
-
-# Excited news!
-
-*This is firmware for the revised, rebooted version of the Chameleon Mini rev E which so many of you bought.
+*This is firmware for the revised, rebooted version of the ChameleonMini RevE Rebooted which so many of you bought.
 The chinese manufacturer had its firmware changes to themself which was limiting for all who bought this device.
 After talks with manufacturer, they also came to the conclusion that it should be open-sourced.  I managed to get source from them and agreed to make a public repository on GitHub.
-Since this firmware isn't in the official Chameleon mini repo,  I decided to make a 'iceman fork' of it.*
+Since this firmware isn't in the official ChameleonMini repo,  I decided to make a 'iceman fork' of it.*
 
 ## Notice
-Let us make this fork awesome to play with. Do please play with it. Get excited and experiment with your enhanced Chameleon Mini device!
+Let us make this fork awesome to play with. Do please play with it. Get excited and experiment with your enhanced ChameleonMini device!
 
 ## First Steps
-This repo is focused on RevE Rebooted, you can find useful information on [our wiki here](https://github.com/iceman1001/ChameleonMini-rebooted/wiki)
+This repo is focused on RevE Rebooted. Start with reading our [Wiki](https://github.com/iceman1001/ChameleonMini-rebooted/wiki).
 
 ### To upgrade the firmware of your ChameleonMini
 
-For RevG owners,
-please visit the [Getting Started page](https://rawgit.com/emsec/ChameleonMini/master/Doc/Doxygen/html/_page__getting_started.html) from the [doxygen documentation](https://rawgit.com/emsec/ChameleonMini/master/Doc/Doxygen/html/index.html).
+For RevG owners, please visit the [Getting Started page](https://rawgit.com/emsec/ChameleonMini/master/Doc/Doxygen/html/_page__getting_started.html) from the [doxygen documentation](https://rawgit.com/emsec/ChameleonMini/master/Doc/Doxygen/html/index.html).
 
-For RevE Rebooted owners,
-please start with the [Windows walkthrough](https://github.com/iceman1001/ChameleonMini-rebooted/wiki/Getting-started)
-
+For RevE Rebooted owners, please start with our [Getting Started](https://github.com/iceman1001/ChameleonMini-rebooted/wiki/Getting-started)
 
 ## Supported Cards and Codecs
 See [here](https://github.com/emsec/ChameleonMini/wiki/Supported-Cards-and--Codecs).
 
-
 ## GUI
-Based on the partial source code release for the GUI we created a new GUI.
-[iceman Chameleon Mini GUI](https://github.com/iceman1001/ChameleonMini-rebootedGUI)
+Based on the partial source code release for the GUI, we created a new GUI: [iceman's ChameleonMini rebootedGUI](https://github.com/iceman1001/ChameleonMini-rebootedGUI)
 It is a windows .net based software and it is really nice to work with.
-Has support for Chameleon Mini revE / revG commands
-and dump management,
-and color templates for dumps,
-and multilanguage
+Has support for ChameleonMini revE / revG commands, dump management, color templates for dumps, and multilanguage.
 
 Built by @bogition and @iceman1001
 
 ## Questions
-If you have any questions, please visit the issues page to the related hardware device you own and ask your questions there so everyone benefits from the answer.
+If you have any questions, please start with reading our [Wiki](https://github.com/iceman1001/ChameleonMini-rebooted/wiki).
+If not enough visit the issues page to the related hardware device you own, and ask your questions there so everyone benefits from the answer.
 
-For RevG owners,
-please visit the [REV_G Issues page](https://github.com/emsec/ChameleonMini/issues)
+For RevG owners, please visit the [RevG Issues page](https://github.com/emsec/ChameleonMini/issues)
 
-For RevE Rebooted owners,
-please visit the [REV_E Rebooted Issues page](https://github.com/iceman1001/ChameleonMini-rebooted/issues)
-
+For RevE Rebooted owners, please visit the [RevE Rebooted Issues page](https://github.com/iceman1001/ChameleonMini-rebooted/issues)
 
 ## Repository Structure
-The code repository contains
+The code repository contains:
 * Drivers: Chameleon drivers for Windows and Linux
 * Firmware: The complete firmware including a modified Atmel DFU bootloader and LUFA
 * Software: Contains a python tool for an easy configuration (and more) of the ChameleonMini, Note that this is currently under construction
@@ -73,8 +58,7 @@ The code repository contains
 | Lab401 | [https://lab401.com/][store3] | Rev E Rebooted |
 
 ## Donate
-If you feel the love,  do feel free to become a iceman patron. For some tiers it comes with rewards
-https://www.patreon.com/iceman1001
+If you feel the love,  do feel free to become a iceman patron. For some tiers it comes with rewards https://www.patreon.com/iceman1001
 
 All support is welcome.
 


### PR DESCRIPTION
I did the Wiki already.
That's for Readme. I also stripped all line breaks that were not interpreted by Markdown anyway (a line break is space-space-enter with Markdown... yeah...). It is good for readability as it is anyway.
I will do the full repo after that, then another pass on wiki if full repo PR is merged.