### PR TITLE
Create a documented issue template for bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,6 +1,7 @@
 ---
 name: 'Bug Report'
 about: 'Something did not function as expected, and you would like to help fixing it.
+title: '[BUG] Please enter a short description'
 labels: 'bug'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,58 @@
+<!-- Everything wrote in between such markers before and after this phrase are comments, will not be displayed, and are to be replaced or can be deleted. The rest is to let untouched, except where specified, or your report will be ugly. Use "Preview" tab just above to check how things will be displayed. -->
+<!-- If you do not understand what is requested somewhere in here, please read Wiki pages and read other issues first. -->
+## Context
+### Prerequisites
+<!-- Put an "X" for each item you achieved or agree with, between [ ], like this: [X]. If you do not know, do not check. You are most probably not ready to submit a bug report if not all items are checked, or the bug report should not be submitted on this repository: if you do so anyway, you may receive no feedback. -->
+* [ ] I can reproduce the issue/bug that I report on
+* [ ] I run the latest version of the firmware from this repository
+* [ ] I am available to provide further details, and can reproduce the same initial situation where I identified the issue
+* [ ] I checked all available open sources, like Wiki, Internet search engines, and other issues, to document what I found in the better possible extent, confirm that something did not function as expected, and that a bug fix is required in this repository code
+* [ ] I checked for issues here, and did not find this one was already reported on
+* [ ] I understand this repository or issue tracker is not a support service for the hardware I bought, but a cooperative open-source project to play with it, and that nobody here is affiliated with ChameleonMini manufacturers or sellers
+### Environment
+<!-- Write your information on the right column between the | | characters. Do not delete/modify any | character. If you need to use a | character in your writing, or code, put them between back-quotes, `like this`. -->
+|Item|Your information|
+|---|---|
+|**Harware**|<!-- Version of your hardware: RevE Rebboted, RevG, Other, I don't known. If you don't know, it's probably written on it under the Chameleon picture. As a reminder, this repositoty only supports RevE Rebooted for now -->
+|**Buying source**|<!-- Put a URL to the merchant website where you  bought your ChameleonMini, or write a description of it. -->|
+|**Firmware**|<!-- Write the full version name of your firmware. Use the "VERSION" command, or look at "Settings" tab in GUI. -->|
+|**GUI**|<!-- Put a URL to file or repository source whre you found the GUI you are using to program or configure your ChameleonMini. If you do not use one and use commands only, type Terminal. As a reminder, rebootedGUI only is supposed to work with firmware in this repo. -->|
+|**Slot number**|<!-- Put the slot number you are using when the bug appears, from 1 to 8. If it is not applicable, put N/A. -->|
+|**Slot configuration**|<!-- Write the setting name of the slot you are using when the bug appears. The setting name might be one like "MF_CLASSIC_1K" or "MF_DETECTION", amongst the list found on wiki here: https://github.com/iceman1001/ChameleonMini-rebooted/wiki/Configurations. If it is not applicable, put N/A. -->|
+|**Dump source**|<!-- If you are using a card dump on the slot when the bug appears, briefly describe where your dump come from (card source, how did you dump it). If it is not applicable, put N/A. -->|
+|**Reader**|<!-- Briefly describe the reader or device to which you applied your ChameleonMini (brand, type, use case). If it is not applicable, put N/A. -->|
+|**Flashing environment**|<!-- Briefly describe the environment from which you compile, flash and program your CHameleonMini (OS, version). If you use different ones from different activities, or could reproduce the bug on different environments, describe them all. If it is not applicable, put N/A. -->|
+|**Flashing interface**|<!-- How do you connect your ChameleonMini to your computer to flash it. Please specify amongst: USB, AVRISPmkII, other (describe). If it is not applicable, put N/A. -->|
+|**Flashing method**|<!-- How do you flash a firmware to your ChameleonMini. Please specify amongst: dfu-programmer, flash.bat, BOOT_LOADER_EXE.exe, avrdude, other (describe). If it is not applicable, put N/A. -->|
+|**Flash memory space**|<!-- How many flash memory space do you have in your device. Find this information with "SPI_FLASHINFO" command. -->|
+|**Makefile configuration**|<!-- Tell which configuration/settings you tuned in Makefile. If it is not applicable, put N/A. -->|
+### About my use
+<!-- Please briefly describe how/why you mainly use a ChameleonMini, and what you are trying to do with it. -->
+### About me
+<!-- Put an "X" for each item you achieved or agree with, between [ ], like this: [X]. If you do not know, do not check. -->
+* [ ] I have knowledge on RFID/NFC standards and/or technologies
+* [ ] I know how to program (<!-- Please detail relevant langages that are used within this repo if you want: C, Bash, Python, etc. -->)
+* [ ] I have knowledge on AVR microcontrollers programming
+* [ ] I know how to do a Pull Request (PR), or am OK to learn it and try it
+
+## Bug description
+### Situation
+<!-- Please describe what you are trying to do when the bug appears, and in which situation. Please also describe the 2 or 3 last things you did with your ChameleonMini before you were in the situation where the bug appeared, if possible. -->
+### Expected function and references
+<!-- Please describe how things are supposed to work from your perspective, and give URL or paths to this repository or Wiki pages that actually tell this is how it is supposed to happen. -->
+### Bug
+<!-- Please describe the bug you identified, i.e. in what ways it did not function as expected. -->
+<!-- Give as much details as possible. Include commands, terminal output, and/or code lines where relevant, between back-quotes `like this` for a simple line, or between back-quotes paragraphs for multiple lines ``` LIKE THIS ```. -->
+### Steps to Reproduce
+<!-- Provide a link to a live example, images if relevant (GUI for instance), and/or an unambiguous set of actions to reproduce this bug. Include commands, terminal output, and/or code lines to reproduce, between back-quotes `like this` if relevant. -->
+1.
+2. ...
+
+## Resolution paths
+### Ideas
+<!-- Describe any idea you have to fix the issue, if any. Put N/A if you do not have any. -->
+### Possible Implementation
+<!-- If you have any suggested implementation to fix the issue, including code, put it here between back-quotes paragraphs ``` LIKE THIS ```. Put N/A if you do not have any. -->
+
+<!-- Thanks in advance for submitting a complete bug report -->
+

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,45 +1,24 @@
 <!-- Everything wrote in between such markers before and after this phrase are comments, will not be displayed, and are to be replaced or can be deleted. The rest is to let untouched, except where specified, or your report will be ugly. Use "Preview" tab just above to check how things will be displayed. -->
 <!-- If you do not understand what is requested somewhere in here, please read Wiki pages and read other issues first. -->
-## Context
-### Prerequisites
-<!-- Put an "X" for each item you achieved or agree with, between [ ], like this: [X]. If you do not know, do not check. You are most probably not ready to submit a bug report if not all items are checked, or the bug report should not be submitted on this repository: if you do so anyway, you may receive no feedback. -->
-* [ ] I can reproduce the issue/bug that I report on
-* [ ] I run the latest version of the firmware from this repository
-* [ ] I am available to provide further details, and can reproduce the same initial situation where I identified the issue
-* [ ] I checked all available open sources, like Wiki, Internet search engines, and other issues, to document what I found in the better possible extent, confirm that something did not function as expected, and that a bug fix is required in this repository code
-* [ ] I checked for issues here, and did not find this one was already reported on
-* [ ] I understand this repository or issue tracker is not a support service for the hardware I bought, but a cooperative open-source project to play with it, and that nobody here is affiliated with ChameleonMini manufacturers or sellers
-### Environment
-<!-- Write your information on the right column between the | | characters. Do not delete/modify any | character. If you need to use a | character in your writing, or code, put them between back-quotes, `like this`. -->
+## Environment
+<!-- Write your information on the right column between the | | characters. Do not delete/modify any | character. If you need to use a | character in your writing, or code, put them between back-quotes, `like | this`. -->
 |Item|Your information|
 |---|---|
-|**Harware**|<!-- Version of your hardware: RevE Rebboted, RevG, Other, I don't known. If you don't know, it's probably written on it under the Chameleon picture. As a reminder, this repositoty only supports RevE Rebooted for now -->
-|**Buying source**|<!-- Put a URL to the merchant website where you  bought your ChameleonMini, or write a description of it. -->|
+|**Harware**|<!-- Version of your hardware: RevE Rebooted, RevG, Other, I don't known. If you don't know, it's probably written on it under the Chameleon picture. As a reminder, this repositoty only supports RevE Rebooted for now -->
 |**Firmware**|<!-- Write the full version name of your firmware. Use the "VERSION" command, or look at "Settings" tab in GUI. -->|
-|**GUI**|<!-- Put a URL to file or repository source whre you found the GUI you are using to program or configure your ChameleonMini. If you do not use one and use commands only, type Terminal. As a reminder, rebootedGUI only is supposed to work with firmware in this repo. -->|
+|**GUI**|<!-- Put a URL to file or repository source whre you found the GUI you are using to program or configure your ChameleonMini. If you do not use one and use commands only, type Terminal. Firmware in this repo is fully supported by rebootedGUI only. -->|
 |**Slot number**|<!-- Put the slot number you are using when the bug appears, from 1 to 8. If it is not applicable, put N/A. -->|
 |**Slot configuration**|<!-- Write the setting name of the slot you are using when the bug appears. The setting name might be one like "MF_CLASSIC_1K" or "MF_DETECTION", amongst the list found on wiki here: https://github.com/iceman1001/ChameleonMini-rebooted/wiki/Configurations. If it is not applicable, put N/A. -->|
 |**Dump source**|<!-- If you are using a card dump on the slot when the bug appears, briefly describe where your dump come from (card source, how did you dump it). If it is not applicable, put N/A. -->|
 |**Reader**|<!-- Briefly describe the reader or device to which you applied your ChameleonMini (brand, type, use case). If it is not applicable, put N/A. -->|
-|**Flashing environment**|<!-- Briefly describe the environment from which you compile, flash and program your CHameleonMini (OS, version). If you use different ones from different activities, or could reproduce the bug on different environments, describe them all. If it is not applicable, put N/A. -->|
-|**Flashing interface**|<!-- How do you connect your ChameleonMini to your computer to flash it. Please specify amongst: USB, AVRISPmkII, other (describe). If it is not applicable, put N/A. -->|
-|**Flashing method**|<!-- How do you flash a firmware to your ChameleonMini. Please specify amongst: dfu-programmer, flash.bat, BOOT_LOADER_EXE.exe, avrdude, other (describe). If it is not applicable, put N/A. -->|
+|**Flashing environment**|<!-- Briefly describe the environment from which you compile, flash and program your ChameleonMini (OS, version). If you use different ones from different activities, or could reproduce the bug on different environments, describe them all. If it is not applicable, put N/A. -->|
+|**Flashing method**|<!-- How do you connect and flash your ChameleonMini to your computer to flash it. Please specify amongst: USB, AVRISPmkII, dfu-programmer, flash.bat, BOOT_LOADER_EXE.exe, other (describe). If it is not applicable, put N/A. -->|
 |**Flash memory space**|<!-- How many flash memory space do you have in your device. Find this information with "SPI_FLASHINFO" command. -->|
-|**Makefile configuration**|<!-- Tell which configuration/settings you tuned in Makefile. If it is not applicable, put N/A. -->|
-### About my use
-<!-- Please briefly describe how/why you mainly use a ChameleonMini, and what you are trying to do with it. -->
-### About me
-<!-- Put an "X" for each item you achieved or agree with, between [ ], like this: [X]. If you do not know, do not check. -->
-* [ ] I have knowledge on RFID/NFC standards and/or technologies
-* [ ] I know how to program (<!-- Please detail relevant langages that are used within this repo if you want: C, Bash, Python, etc. -->)
-* [ ] I have knowledge on AVR microcontrollers programming
-* [ ] I know how to do a Pull Request (PR), or am OK to learn it and try it
+|**Makefile configuration**|<!-- Tell which configuration/settings you tuned in Makefile. If it is not applicable or if you did not touch Makefile, put N/A. -->|
 
 ## Bug description
-### Situation
-<!-- Please describe what you are trying to do when the bug appears, and in which situation. Please also describe the 2 or 3 last things you did with your ChameleonMini before you were in the situation where the bug appeared, if possible. -->
 ### Expected function and references
-<!-- Please describe how things are supposed to work from your perspective, and give URL or paths to this repository or Wiki pages that actually tell this is how it is supposed to happen. -->
+<!-- Please describe how things are supposed to work from your perspective. Do not hesitate to give URL or paths to this repository or Wiki pages to reference what you are trying to achieve. -->
 ### Bug
 <!-- Please describe the bug you identified, i.e. in what ways it did not function as expected. -->
 <!-- Give as much details as possible. Include commands, terminal output, and/or code lines where relevant, between back-quotes `like this` for a simple line, or between back-quotes paragraphs for multiple lines ``` LIKE THIS ```. -->

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,3 +1,10 @@
+---
+name: 'Bug Report'
+about: 'Something did not function as expected, and you would like to help fixing it.
+labels: 'bug'
+assignees: ''
+
+---
 <!-- Everything wrote in between such markers before and after this phrase are comments, will not be displayed, and are to be replaced or can be deleted. The rest is to let untouched, except where specified, or your report will be ugly. Use "Preview" tab just above to check how things will be displayed. -->
 <!-- If you do not understand what is requested somewhere in here, please read Wiki pages and read other issues first. -->
 ## Environment


### PR DESCRIPTION
This should ensure proper and complete information for bugs opening, as well as some sort of maniac-filter.
Next in anti-social-networks-confusion plan, templates to request enhancement/features, template to just ask questions and discuss because Facebook is offline, template to inform, and template to just get feedback before implementing something.

Use the "view file" on the created file to see the rendered result.