### PR TITLE
Added required xcl file to build bootloader

### DIFF
--- a/Firmware/Atmel-DFU-Bootloader/.gitignore
+++ b/Firmware/Atmel-DFU-Bootloader/.gitignore
@@ -52,7 +52,6 @@ settings/
 *.dbgdt
 *.cspy
 *.cspy.*
-*.xcl
 *.dni
 *.wsdt
 *.wspos

--- a/Firmware/Atmel-DFU-Bootloader/common/services/usb/class/dfu_flip/device/bootloader/xmega/atxmega32a4u/iar/atxmega32a4u_boot.xcl
+++ b/Firmware/Atmel-DFU-Bootloader/common/services/usb/class/dfu_flip/device/bootloader/xmega/atxmega32a4u/iar/atxmega32a4u_boot.xcl
@@ -1,0 +1,102 @@
+/**
+ * \file
+ *
+ * \brief Linker script for ATxmega32A4U USB DFU FLIP bootloader
+ *
+ * Copyright (c) 2011 - 2012 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+// Set up XLINK
+-ca90
+-w29
+
+// Memory size definitions for convenience
+// The '_..X_' prefix is used by C-SPY as an indication that the label should
+// not be displayed in the dissassembly window.
+-D_..X_FLASH_BASE=8002
+-D_..X_CODE_END=8FFF
+-D_..X_INTVEC_END=81FB
+
+
+
+//////////////////////////////////////////////////////////////////////////////
+// Code (flash) segments
+-Z(CODE)INTVEC=81F4-81FF
+-P(CODE)BOOT=_..X_FLASH_BASE-_..X_CODE_END
+-P(CODE)CODE=_..X_FLASH_BASE-_..X_CODE_END
+-P(CODE)FARCODE=_..X_FLASH_BASE-_..X_CODE_END
+-Z(CODE)INITTAB=81FC-_..X_CODE_END
+-Z(CODE)NEAR_ID=81FC-_..X_CODE_END
+
+
+-D_..X_SRAM_BASE=2000
+-D_..X_SRAM_TINY_END=FF
+-D_..X_SRAM_NEAR_END=FFFF
+-D_..X_SRAM_FAR_END=FFFFFF
+-D_..X_SRAM_HUGE_END=FFFFFF
+
+/*
+ * Modify the lines below to alter the size of the RSTACK, CSTACK and HEAP
+ * segments. These need to be fine tuned to suit your specific application.
+ */
+-D_..X_CSTACK_SIZE=70 /* 112 bytes for auto variables and register save. */
+-D_..X_RSTACK_SIZE=70  /* 112 bytes for return addresses, equivalent to */
+                        /* 56 levels of calls, including interrupts. */
+-D_..X_NEAR_HEAP_SIZE=1000   /* 4096 bytes of heap. */
+-D_..X_HEAP_SIZE=1000   /* 4096 bytes of heap. */
+-D_..X_FAR_HEAP_SIZE=1000   /* 4096 bytes of heap. */
+-D_..X_HUGE_HEAP_SIZE=1000   /* 4096 bytes of heap. */
+//////////////////////////////////////////////////////////////////////////////
+// Data (SRAM, external ROM or external NV RAM) memory
+-Z(DATA)SRAM_NO_INIT=2000-2001
+-Z(DATA)TINY_I,TINY_Z,TINY_N=_..X_SRAM_BASE-_..X_SRAM_NEAR_END
+-Z(DATA)RSTACK+_..X_RSTACK_SIZE=_..X_SRAM_BASE-_..X_SRAM_NEAR_END
+-Z(DATA)NEAR_I,NEAR_Z,NEAR_N,NEAR_C=_..X_SRAM_BASE-_..X_SRAM_NEAR_END
+-Z(DATA)NEAR_HEAP+_..X_NEAR_HEAP_SIZE=_..X_SRAM_BASE-_..X_SRAM_NEAR_END
+//-Z(DATA)FAR_I=[10000-_..X_SRAM_FAR_END]/10000
+-Z(DATA)CSTACK+_..X_CSTACK_SIZE=[_..X_SRAM_BASE-_..X_SRAM_FAR_END]/10000
+-Z(DATA)HEAP+_..X_HEAP_SIZE=[_..X_SRAM_BASE-_..X_SRAM_FAR_END]/10000
+-Z(DATA)IOSTREAM_N#[_..X_SRAM_BASE-_..X_SRAM_FAR_END]/10000
+-Z(DATA)FAR_Z,FAR_N,FAR_C=[_..X_SRAM_BASE-_..X_SRAM_FAR_END]/10000
+-Z(DATA)FAR_HEAP+_..X_FAR_HEAP_SIZE=_..X_SRAM_BASE-_..X_SRAM_FAR_END
+-Z(DATA)HUGE_I,HUGE_Z,HUGE_N,HUGE_C=_..X_SRAM_BASE-_..X_SRAM_HUGE_END
+-Z(DATA)HUGE_HEAP+_..X_HUGE_HEAP_SIZE=_..X_SRAM_BASE-_..X_SRAM_HUGE_END
+
+
+
+


### PR DESCRIPTION
Fix: added a missing file to build bootloader with AVR IAR Workbench.
The bootloader sources compile, flash and function successfully with ChameleonMini RevE Rebooted as of today.