### PR TITLE
Memory polish

### DIFF
--- a/Firmware/ChameleonMini/Configuration.c
+++ b/Firmware/ChameleonMini/Configuration.c
@@ -270,7 +270,7 @@ void ConfigurationGetList(char* List, uint16_t BufferSize)
     MapToString(ConfigurationMap, ARRAY_COUNT(ConfigurationMap), List, BufferSize);
 }
 
-uint16_t ConfigurationTableGetMemorySizeForId(ConfigurationEnum Configuration) {
+uint32_t ConfigurationTableGetMemorySizeForId(ConfigurationEnum Configuration) {
     /* Possible other implementation
     ConfigurationType ConfForSetting;
     memcpy_P( &ConfForSetting,
@@ -278,6 +278,6 @@ uint16_t ConfigurationTableGetMemorySizeForId(ConfigurationEnum Configuration) {
               sizeof(ConfigurationType) );
     return ConfForSetting.MemorySize;
     */
-    return ( (uint16_t)pgm_read_word( &(ConfigurationTable[Configuration].MemorySize) ) );
+    return ( (uint32_t)pgm_read_dword( &(ConfigurationTable[Configuration].MemorySize) ) );
 }
 

--- a/Firmware/ChameleonMini/Configuration.c
+++ b/Firmware/ChameleonMini/Configuration.c
@@ -5,11 +5,10 @@
  *      Author: skuser
  */
 
+#include <avr/pgmspace.h>
 #include "Configuration.h"
 #include "Settings.h"
-#include <avr/pgmspace.h>
 #include "Map.h"
-#include "AntennaLevel.h"
 
 /* Map IDs to text */
 static const MapEntryType PROGMEM ConfigurationMap[] = {
@@ -46,13 +45,13 @@ static void ApplicationInitDummy(void) {}
 static void ApplicationResetDummy(void) {}
 static void ApplicationTaskDummy(void) {}
 static void ApplicationTickDummy(void) {}
-static uint16_t ApplicationProcessDummy(uint8_t* ByteBuffer, uint16_t ByteCount) { return 0; }
-static void ApplicationGetUidDummy(ConfigurationUidType Uid) { }
+static uint16_t ApplicationProcessDummy(uint8_t* ByteBuffer, uint16_t ByteCount) { return CONFIGURATION_DUMMY_UID_PART; }
+static void ApplicationGetUidDummy(ConfigurationUidType Uid) { memset(Uid, CONFIGURATION_DUMMY_UID_PART, CONFIGURATION_DUMMY_UID_SIZE); }
 static void ApplicationSetUidDummy(ConfigurationUidType Uid) { }
-static void ApplicationGetAtqaDummy(uint16_t * Atqa) { }
+static void ApplicationGetAtqaDummy(uint16_t * Atqa) { *Atqa = CONFIGURATION_DUMMY_ATQA; }
 static void ApplicationSetAtqaDummy(uint16_t Atqa) { }
-static void ApplicationGetSakDummy(uint8_t * Atqa) { }
-static void ApplicationSetSakDummy(uint8_t Atqa) { }
+static void ApplicationGetSakDummy(uint8_t * Sak) { *Sak = CONFIGURATION_DUMMY_SAK; }
+static void ApplicationSetSakDummy(uint8_t Sak) { }
 
 static const PROGMEM ConfigurationType ConfigurationTable[] = {
 [CONFIG_NONE] = {

--- a/Firmware/ChameleonMini/Configuration.h
+++ b/Firmware/ChameleonMini/Configuration.h
@@ -4,7 +4,6 @@
  *  Created on: 15.02.2013
  *      Author: skuser
  */
-/** \file */
 #ifndef _CM_CONFIGURATION_H_
 #define _CM_CONFIGURATION_H_
 
@@ -14,6 +13,9 @@
 #define CONFIGURATION_NAME_LENGTH_MAX   32
 #define CONFIGURATION_UID_SIZE_MAX      16
 #define CONFIGURATION_DUMMY_UID_SIZE    4
+#define CONFIGURATION_DUMMY_UID_PART    0x00
+#define CONFIGURATION_DUMMY_ATQA        0x0000
+#define CONFIGURATION_DUMMY_SAK         0x00
 #define CONFIGURATION_DUMMY_MEMSIZE     16
 
 typedef uint8_t ConfigurationUidType[CONFIGURATION_UID_SIZE_MAX];

--- a/Firmware/ChameleonMini/Configuration.h
+++ b/Firmware/ChameleonMini/Configuration.h
@@ -133,7 +133,7 @@ typedef struct {
      * Defines how many space the configuration needs. For emulating configurations this is the memory space of
      * the emulated card.
      */
-    uint16_t MemorySize;
+    uint32_t MemorySize;
     /**
      * Defines the size of the UID for emulating configurations.
      */
@@ -152,6 +152,6 @@ void ConfigurationSetById(ConfigurationEnum Configuration);
 void ConfigurationGetByName(char* Configuration, uint16_t BufferSize);
 bool ConfigurationSetByName(const char* Configuration);
 void ConfigurationGetList(char* ConfigurationList, uint16_t BufferSize);
-uint16_t ConfigurationTableGetMemorySizeForId(ConfigurationEnum Configuration);
+uint32_t ConfigurationTableGetMemorySizeForId(ConfigurationEnum Configuration);
 
 #endif /* _CM_CONFIGURATION_H_ */

--- a/Firmware/ChameleonMini/Memory/EEPROM.c
+++ b/Firmware/ChameleonMini/Memory/EEPROM.c
@@ -14,6 +14,9 @@
 // Dummy init to prepare for future use
 bool EEPROMInit(void) {
     bool ret = false;
+    // Enable EEPROM data memory mapping
+    NVM.CTRLB |= NVM_EEMAPEN_bm;
+    // Calculate available EEPROM size per setting
     if (EEPROM_BYTES_TOTAL > EEPROM_NO_MEMORY) {
         EEPROMInfo.bytesTotal = EEPROM_BYTES_TOTAL;
         ret = true;

--- a/Firmware/ChameleonMini/Memory/Memory.c
+++ b/Firmware/ChameleonMini/Memory/Memory.c
@@ -99,7 +99,13 @@ bool AppMemoryRead(void* Buffer, uint32_t Address, uint32_t ByteCount) {
 }
 
 bool AppMemoryDownloadXModem(void* Buffer, uint32_t Address, uint32_t ByteCount) {
-    return AppMemoryRead(Buffer, Address, ByteCount);
+    bool ret = false;
+    uint32_t AvailBytes = getAppMemSizeForSetting(GlobalSettings.ActiveSetting);
+    if(Address < AvailBytes) {
+        uint32_t BytesLeft = MIN(ByteCount, AvailBytes - Address);
+        ret = AppMemoryRead(Buffer, Address, BytesLeft);
+    }
+    return ret;
 }
 
 /* Memory write operations
@@ -118,7 +124,13 @@ bool AppMemoryWrite(const void* Buffer, uint32_t Address, uint32_t ByteCount) {
 }
 
 bool AppMemoryUploadXModem(void* Buffer, uint32_t Address, uint32_t ByteCount) {
-    return AppMemoryWrite((const void *)Buffer, Address, ByteCount);
+    bool ret = false;
+    uint32_t AvailBytes = getAppMemSizeForSetting(GlobalSettings.ActiveSetting);
+    if(Address < AvailBytes) {
+        uint32_t BytesLeft = MIN(ByteCount, AvailBytes - Address);
+        ret = AppMemoryWrite((const void *)Buffer, Address, BytesLeft);
+    }
+    return ret;
 }
 
 /* Memory delete/clear operations

--- a/Firmware/ChameleonMini/Memory/SPIFlash.h
+++ b/Firmware/ChameleonMini/Memory/SPIFlash.h
@@ -82,6 +82,7 @@
 #define FLASH_STATUS_PAGESIZE_BIT   0x01 // Flash page size setting (0 is default, 1 is binary)
 
 #define FLASH_DUMMY_BYTE            0x00
+#define FLASH_CLEAR_BYTE            0xFF
 #define FLASH_NO_OFFSET             0
 #define FLASH_NO_PAGE               0
 #define FLASH_B_IN_KB               1024

--- a/Firmware/ChameleonMini/System.c
+++ b/Firmware/ChameleonMini/System.c
@@ -38,9 +38,6 @@ void SystemInit(void)
     /* Enable RTC with roughly 1kHz clock */
     CLK.RTCCTRL = CLK_RTCSRC_ULP_gc | CLK_RTCEN_bm;
     RTC.CTRL = RTC_PRESCALER_DIV1_gc;
-
-    /* Enable EEPROM data memory mapping */
-    NVM.CTRLB |= NVM_EEMAPEN_bm;
 }
 
 void SystemReset(void)

--- a/Firmware/ChameleonMini/Terminal/Commands.c
+++ b/Firmware/ChameleonMini/Terminal/Commands.c
@@ -437,34 +437,35 @@ CommandStatusIdType CommandExecMemoryInfo(char* OutMessage)
 CommandStatusIdType CommandExecMemoryTest(char* OutMessage)
 {
     uint8_t bigbuf[512];
-    uint8_t readbuf[70];
+    uint8_t readbuf[56];
+    uint8_t expected[56];
+    HexStringToBuffer(expected, 56, "11111111AAAAAAAAAAAA03111111111111111111110011111111AAAAAAAAAAAA03FFFFFFFFFFFFFFFFFFFF00FFFFFFFFFFFFFFFFFFFF05AA");
     memset(bigbuf, 0x11, 512);
-    memset(readbuf, 0xAA, 70);
+    memset(readbuf, 0xAA, 56);
 
     SettingsSetActiveById(3);
-    ConfigurationSetById(CONFIG_MF_CLASSIC_1K);
+    ConfigurationSetById(CONFIG_NONE);
     SettingsSave();
     SettingsSetActiveById(0);
     ConfigurationSetById(CONFIG_MF_CLASSIC_4K);
     SettingsSave();
 
     AppMemoryWriteForSetting(3, bigbuf, 0, 512);
-    AppMemoryWriteForSetting(3, bigbuf, 512, 512);
     for(uint8_t i = 0; i < 8; i++){
          AppMemoryWrite(bigbuf, i*512, 512);
     }
-    FlashUnbufferedBytesRead(readbuf, 3*MemoryMappingInfo.maxFlashBytesPerSlot+1023, 1);
-    AppMemoryReadForSetting(3, readbuf+1, 250, 9);
+    FlashUnbufferedBytesRead(readbuf, 3*MemoryMappingInfo.maxFlashBytesPerSlot, 4);
+    AppMemoryReadForSetting(3, readbuf+4, 250, 6);
     readbuf[10] = 0x03;
     FlashUnbufferedBytesRead(readbuf+11, 1024, 1);
     FlashUnbufferedBytesRead(readbuf+12, 3118, 2);
     AppMemoryRead(readbuf+14, 2046, 3);
     AppMemoryRead(readbuf+17, 12, 4);
     readbuf[21] = 0x00;
-    FlashClearRange(3*MemoryMappingInfo.maxFlashBytesPerSlot, 1023);
+    FlashClearRange(3*MemoryMappingInfo.maxFlashBytesPerSlot, 15);
     AppMemoryClear();
-    FlashUnbufferedBytesRead(readbuf+22, 3*MemoryMappingInfo.maxFlashBytesPerSlot+1023, 1);
-    AppMemoryReadForSetting(3, readbuf+23, 250, 9);
+    FlashUnbufferedBytesRead(readbuf+22, 3*MemoryMappingInfo.maxFlashBytesPerSlot, 4);
+    AppMemoryReadForSetting(3, readbuf+26, 250, 6);
     readbuf[32] = 0x03;
     FlashUnbufferedBytesRead(readbuf+33, 1024, 1);
     FlashUnbufferedBytesRead(readbuf+34, 3118, 2);


### PR DESCRIPTION
Move EEPROM system init to memory rewrite, fix #148 by better limiting XModem upload/download R/W sizes, allow flash erase for spaces that are less than a page, and fix "CLOSED" settings standard data returns (I noticed they were generating random RAM reads).