### PR TITLE
Flash model fix

### DIFF
--- a/Firmware/ChameleonMini/Memory/SPIFlash.c
+++ b/Firmware/ChameleonMini/Memory/SPIFlash.c
@@ -37,8 +37,10 @@
 #include "../Common.h"
 
 // Operating parameters for the different size flash chips that are supported
-static const flashGeometry_t AT45DBXX1E[] PROGMEM = {
+static const flashGeometry_t AT45DBXX1X[] PROGMEM = {
 /*
+SPI Flash chips on ChameleonMini RevE rebooted are supposed to be AT45DBXX1D-SSU.
+This library will also work with AT45DBXX1E more recent family.
 ID = densityCode - FLASH_MDID_ID_OFFSET
 Sector (s) > Block (b) > Page (p) > Byte (B)
 53,50,7c,7c,B/p,   np, B/b,  nb,  B/sN, /0a,   /0b,ns,sM, sKB,sB
@@ -122,8 +124,7 @@ INLINE void sendAddrOp(uint8_t Op, uint32_t Address) {
 ***************************************************************************************/
 
 // Get sure we set the binary page format
-// During tests, ChameleonMini SPI flash chip could not be set to DataFlash
-// format, probably because of faulty chips, or previous configuration overflow
+// AT45DBXXD cannot be set back to 264 bits pages when set once to 256 bits pages.
 // (page size configuration is limited to 10000 configurations).
 INLINE void FlashConfigurePageSize(void) {
     if( !(FlashReadStatusRegister() & FLASH_STATUS_PAGESIZE_BIT) ) {
@@ -154,7 +155,7 @@ INLINE bool FillFlashInfo(void) {
     FlashInfo.productVariant = FlashInfo.deviceId2 & FLASH_PRODUCT_MASK;
     if( (FlashInfo.densityCode >= FLASH_DENSITY_FIRST)
         && (FlashInfo.densityCode <= FLASH_DENSITY_LAST) ) {
-        memcpy_P( &FlashInfo.geometry, &(AT45DBXX1E[FlashInfo.densityCode - FLASH_MDID_ID_OFFSET]), sizeof(FlashInfo.geometry) );
+        memcpy_P( &FlashInfo.geometry, &(AT45DBXX1X[FlashInfo.densityCode - FLASH_MDID_ID_OFFSET]), sizeof(FlashInfo.geometry) );
         ret = true;
     }
     return ret;

--- a/Firmware/ChameleonMini/Memory/SPIFlash.c
+++ b/Firmware/ChameleonMini/Memory/SPIFlash.c
@@ -218,12 +218,8 @@ bool FlashBufferedBytesWrite(const void* Buffer, uint32_t Address, uint32_t Byte
             OPStop();
             WaitForReadyFlash();
             OPStart();
-            sendAddrOp(FLASH_OP_BUF1_WRITE, Offset);
+            sendAddrOp(FLASH_OP_BUF1_WRITE_PAGE, (PageNum | Offset));
             SPIWriteBlock(Buffer+Head, ByteRoll);
-            OPStop();
-            WaitForReadyFlash();
-            OPStart();
-            sendAddrOp(FLASH_OP_BUF1_TO_PAGE, PageNum);
             OPStop();
             ByteCount -= ByteRoll;
             Address += ByteRoll;

--- a/Firmware/ChameleonMini/Memory/SPIFlash.h
+++ b/Firmware/ChameleonMini/Memory/SPIFlash.h
@@ -62,13 +62,10 @@
 #define FLASH_PRODUCT_MASK          0x1F
 
 #define FLASH_OP_READ               0x0B // Random access continuous read (max freq)
-                                         // Equivalent "1B" did not work during tests,
-                                         // and has not difference for frequently found
-                                         // ChameleonMini memories. Faster than "03".
-#define FLASH_OP_READ_LF            0x03 // Random access continuous read (low freq)
 #define FLASH_OP_PAGE_TO_BUF1       0x53 // Load a page to buffer 1
 #define FLASH_OP_BUF1_WRITE         0x84 // Write into buffer 1
 #define FLASH_OP_BUF1_TO_PAGE       0x83 // Dump buffer 1 into page
+#define FLASH_OP_BUF1_WRITE_PAGE    0x82 // Main Memory Page Program Through Buffer
 #define FLASH_OP_RWM_WITH_BUF1      0x58 // Read-Modify-Write through buffer 1
                                          // Note thats tests with Read-Modify-Write atomic
                                          // operations (58 and 59) failed.
@@ -89,7 +86,6 @@
 #define FLASH_BSIZE                 8 // Bits
 
 #define FLASH_SEQ_PAGE_SIZE_BINARY  0x3D, 0x2A, 0x80, 0xA6 // Binary page size (256 bytes)
-#define FLASH_SEQ_PAGE_SIZE_DEFAULT 0x3D, 0x2A, 0x80, 0xA7 // DataFlash (default) page size (264 bytes)
 #define FLASH_SEQ_CHIP_ERASE        0xC7, 0x94, 0x80, 0x9A // erase entire chip
 
 #define FLASH_SECTOR_ADDR_0A        0x00

--- a/Firmware/ChameleonMini/Memory/SPIFlash.h
+++ b/Firmware/ChameleonMini/Memory/SPIFlash.h
@@ -63,12 +63,7 @@
 
 #define FLASH_OP_READ               0x0B // Random access continuous read (max freq)
 #define FLASH_OP_PAGE_TO_BUF1       0x53 // Load a page to buffer 1
-#define FLASH_OP_BUF1_WRITE         0x84 // Write into buffer 1
-#define FLASH_OP_BUF1_TO_PAGE       0x83 // Dump buffer 1 into page
 #define FLASH_OP_BUF1_WRITE_PAGE    0x82 // Main Memory Page Program Through Buffer
-#define FLASH_OP_RWM_WITH_BUF1      0x58 // Read-Modify-Write through buffer 1
-                                         // Note thats tests with Read-Modify-Write atomic
-                                         // operations (58 and 59) failed.
 #define FLASH_OP_GET_STATUS         0xD7 // Read status
 #define FLASH_OP_SECTOR_ERASE       0x7C // Erase a sector
 #define FLASH_OP_BLOCK_ERASE        0x50 // Erase a block
@@ -86,7 +81,7 @@
 #define FLASH_BSIZE                 8 // Bits
 
 #define FLASH_SEQ_PAGE_SIZE_BINARY  0x3D, 0x2A, 0x80, 0xA6 // Binary page size (256 bytes)
-#define FLASH_SEQ_CHIP_ERASE        0xC7, 0x94, 0x80, 0x9A // erase entire chip
+#define FLASH_SEQ_CHIP_ERASE        0xC7, 0x94, 0x80, 0x9A // Erase entire chip
 
 #define FLASH_SECTOR_ADDR_0A        0x00
 #define FLASH_SECTOR_ADDR_0B        0x01


### PR DESCRIPTION
Not a big deal: identified proper data sheet and model for our SPI Flash memory (schematics helped a lot, actually...), that explained why some operations that were supposed to work with AT45DBXX1E did not.
Commented accordingly, and as so, was able to find a more atomic way to write to flash memory.
Will update wiki as well.