### PR TITLE
Allow enough MF_DETECTION mem to prevent overflow

### DIFF
--- a/Firmware/ChameleonMini/Application/Detection.h
+++ b/Firmware/ChameleonMini/Application/Detection.h
@@ -4,6 +4,8 @@
 #include "Application.h"
 #include "ISO14443-3A.h"
 
+#define DETECTION_DIRTFIX_MEM_SIZE          5120
+
  void MifareDetectionInit(void);
  void MifareDetectionReset(void);
  uint16_t MifareDetectionAppProcess(uint8_t* Buffer, uint16_t BitCount);

--- a/Firmware/ChameleonMini/Configuration.c
+++ b/Firmware/ChameleonMini/Configuration.c
@@ -247,7 +247,7 @@ static const PROGMEM ConfigurationType ConfigurationTable[] = {
     .ApplicationGetAtqaFunc = MifareClassicGetAtqa,
     .ApplicationSetAtqaFunc = MifareClassicSetAtqa,
     .UidSize = MIFARE_CLASSIC_UID_SIZE,
-    .MemorySize = MIFARE_CLASSIC_1K_MEM_SIZE,
+    .MemorySize = DETECTION_DIRTFIX_MEM_SIZE,
     .ReadOnly = false
 },
 #endif


### PR DESCRIPTION
In order to quickly fix root cause for issue #151 .
More memory space is requested by MF_DETECTION so that its original code does not R/W to out-of-slot memory (original code based nonces R/W operations to a +4096 arbitrary offset, which is now impossible due to recent memory management fixes). 
Original MF_DETECTION code is unchanged.

Done to ensure testing cases before writing #157 