### PR TITLE
R/W ATQA/SAK from/to application memory

### DIFF
--- a/Firmware/ChameleonMini/Application/MifareClassic.h
+++ b/Firmware/ChameleonMini/Application/MifareClassic.h
@@ -36,6 +36,14 @@
 
 #define MFCLASSIC_MEM_S0B0_ADDRESS              0x00
 #define MFCLASSIC_MEM_INVALID_ADDRESS           0xFF
+#define MFCLASSIC_MEM_SAK_ADDR                  0x05
+#define MFCLASSIC_MEM_7B_SAK_ADDR               0x08
+#define MFCLASSIC_MEM_SAK_SIZE                  1
+#define MFCLASSIC_MEM_SAK_VOID                  0xFF
+#define MFCLASSIC_MEM_ATQA_ADDR                 0x06
+#define MFCLASSIC_MEM_7B_ATQA_ADDR              0x09
+#define MFCLASSIC_MEM_ATQA_SIZE                 2
+#define MFCLASSIC_MEM_ATQA_VOID                 0xFFFF
 #define MFCLASSIC_MEM_UID_CL1_ADDRESS           0x00
 #define MFCLASSIC_MEM_UID_CL1_SIZE              4
 #define MFCLASSIC_MEM_UID_BCC1_ADDRESS          0x04

--- a/Firmware/ChameleonMini/Terminal/Commands.c
+++ b/Firmware/ChameleonMini/Terminal/Commands.c
@@ -109,9 +109,9 @@ CommandStatusIdType CommandGetAtqa(char* OutParam) {
     // Convert uint16 to uint8 buffer[]
     uint8_t atqaBuffer[2] = { 0,0 };
     atqaBuffer[1] = (uint8_t)Atqa;
-    atqaBuffer[0] = Atqa >> 8;
+    atqaBuffer[0] = (uint8_t)(Atqa >> 8);
 
-    BufferToHexString(OutParam, TERMINAL_BUFFER_SIZE, &atqaBuffer, sizeof(uint16_t));
+    BufferToHexString(OutParam, TERMINAL_BUFFER_SIZE, atqaBuffer, sizeof(uint16_t));
 
     return COMMAND_INFO_OK_WITH_TEXT_ID;
 }
@@ -120,18 +120,13 @@ CommandStatusIdType CommandSetAtqa(char* OutMessage, const char* InParam) {
     uint8_t AtqaBuffer[2] = { 0, 0 };
     uint16_t Atqa = 0;
 
-    if (HexStringToBuffer(&AtqaBuffer, sizeof(AtqaBuffer), InParam) != sizeof(uint16_t)) {
+    if (HexStringToBuffer(AtqaBuffer, sizeof(AtqaBuffer), InParam) != sizeof(AtqaBuffer)) {
         // This has to be 4 digits (2 bytes), e.g.: 0004
         return COMMAND_ERR_INVALID_PARAM_ID;
     }
 
     // Convert uint8 buffer[] to uint16
-    if (strlen(InParam) > 2) {
-        Atqa = ((uint16_t)AtqaBuffer[0] << 8) | AtqaBuffer[1];
-    }
-    else {
-        Atqa = AtqaBuffer[0];
-    }
+    Atqa = ((uint16_t)AtqaBuffer[0] << 8) | AtqaBuffer[1];
 
     ApplicationSetAtqa(Atqa);
     return COMMAND_INFO_OK_ID;


### PR DESCRIPTION
ATQA and SAK should be written/read to/from application memory as well, because they are supposed to be stored on S0/B0 for all MifareClassic for instance, and they might be expected to be read directly by reading S0/B0 on some readers.